### PR TITLE
Fix README clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Among infinite possibilities, one version will ultimately prove itself authentic
 ## 📦 Installation
 
 ```bash
-git clone https://github.com/[user]/hronir_encyclopedia
+git clone https://github.com/franklinbaldo/hronir
 cd hronir_encyclopedia
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
## Summary
- fix the clone URL in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68421a0d3ae08325b22dd87536807927