### PR TITLE
Implement CLI basics and add agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS Instructions
+
+## Test and linting
+- Install dependencies using `pip install -r requirements.txt` if needed.
+- Run `pytest` from the repository root after changes. Even if there are no tests, this must succeed.
+
+## Code style
+- Use standard Python style with 4-space indentation.
+- Keep implementations minimal and self-explanatory.
+
+## Documentation
+- Update the README when adding new CLI commands or significant features.

--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ python -m hronir_encyclopedia.cli synthesize --position 3 --variant_id 3_a
 # Generate multiple variants at once
 python -m hronir_encyclopedia.cli synthesize --position 3 --variants 3
 
-# View the current narrative tree
+# View the current narrative tree (prints a simple list for now)
 python -m hronir_encyclopedia.cli tree
 
 # Check Elo rankings for a specific position
 python -m hronir_encyclopedia.cli ranking --position 2
 
-# Validate a human-contributed chapter
+# Validate a human-contributed chapter (checks file location only)
 python -m hronir_encyclopedia.cli validate --chapter book/03/03_human.md
 
 # Submit human contribution to ranking system

--- a/hronir_encyclopedia/__init__.py
+++ b/hronir_encyclopedia/__init__.py
@@ -1,0 +1,4 @@
+"""Hr\u00f6nir Encyclopedia package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/hronir_encyclopedia/cli.py
+++ b/hronir_encyclopedia/cli.py
@@ -1,18 +1,57 @@
 import argparse
+import json
+from pathlib import Path
+
+
+def _placeholder_handler(name):
+    def handler(args):
+        print(f"{name} command is in development.")
+
+    return handler
+
+
+def _cmd_tree(args):
+    index_path = Path(args.index)
+    data = json.loads(index_path.read_text())
+    print(data.get("title", "Hr\u00f6nir Encyclopedia"))
+    for pos, fname in sorted(data.get("chapters", {}).items(), key=lambda x: int(x[0])):
+        print(f"{pos}: {fname}")
+
+
+def _cmd_validate(args):
+    chapter = Path(args.chapter)
+    if not chapter.exists() or not chapter.is_file():
+        print("chapter file not found")
+        return
+    if "book" not in chapter.parts:
+        print("chapter must reside in the book/ directory")
+        return
+    print("chapter looks valid")
 
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Hr\u00f6nir Encyclopedia CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    def _placeholder_handler(name):
-        def handler(args):
-            print(f"{name} command is in development.")
-        return handler
+    synth = subparsers.add_parser("synthesize", help="in development")
+    synth.set_defaults(func=_placeholder_handler("synthesize"))
 
-    for cmd in ["synthesize", "validate", "submit", "tree", "ranking", "export"]:
-        sub = subparsers.add_parser(cmd, help="in development")
-        sub.set_defaults(func=_placeholder_handler(cmd))
+    validate = subparsers.add_parser("validate", help="validate a chapter file")
+    validate.add_argument("chapter", help="path to chapter markdown file")
+    validate.set_defaults(func=_cmd_validate)
+
+    submit = subparsers.add_parser("submit", help="in development")
+    submit.set_defaults(func=_placeholder_handler("submit"))
+
+    tree = subparsers.add_parser("tree", help="print the chapter tree")
+    tree.add_argument("--index", default="book/book_index.json", help="index file")
+    tree.set_defaults(func=_cmd_tree)
+
+    ranking = subparsers.add_parser("ranking", help="in development")
+    ranking.set_defaults(func=_placeholder_handler("ranking"))
+
+    export = subparsers.add_parser("export", help="in development")
+    export.set_defaults(func=_placeholder_handler("export"))
 
     args = parser.parse_args(argv)
     args.func(args)


### PR DESCRIPTION
## Summary
- add AGENTS.md with instructions for Codex agents
- implement simple `tree` and `validate` CLI commands
- add package version and docstring
- clarify README with notes on tree and validate commands

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68425c4ca2bc8325bf0469752e57497a