### PR TITLE
Refine UUID plan and add voting CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ python -m hronir_encyclopedia.cli validate --chapter book/03/03_human.md
 # Submit human contribution to ranking system
 python -m hronir_encyclopedia.cli submit --chapter book/03/03_human.md --author "human"
 
+# Store chapter using UUID layout
+python -m hronir_encyclopedia.cli store book/03/03_human.md --prev 123e4567-e89b-12d3-a456-426614174000
+
+# Validate and repair stored chapters
+python -m hronir_encyclopedia.cli audit
+# Each forking entry receives a deterministic UUID
+
 # Export the highest-ranked path as EPUB
 python -m hronir_encyclopedia.cli export --format epub --path canonical
 ```
@@ -184,9 +191,7 @@ python -m hronir_encyclopedia.cli export --format epub --path canonical
 ### Vote on a literary duel:
 
 ```bash
-curl -X POST /vote \
-  -H "Content-Type: application/json" \
-  -d '{ "position": 3, "winner": "3_a", "loser": "3_b" }'
+python -m hronir_encyclopedia.cli vote --position 3 --winner 3_a --loser 3_b
 ```
 
 ---

--- a/docs/uuid_structure_plan.md
+++ b/docs/uuid_structure_plan.md
@@ -1,0 +1,42 @@
+# Plan for UUID-based Chapter Storage
+
+This document outlines the proposed changes to store chapters using
+content-derived UUIDs rather than the current numeric structure.
+
+## Directory layout
+
+- `hronirs/` – root folder containing every chapter.
+- `forking_path/` – sequence of chapters that form narrative branches.
+- Each chapter will be referenced by a UUID v5 computed from its Markdown
+  contents.
+- To avoid large folder listings, each character of the UUID becomes a
+  directory level. Example for UUID
+  `01234567-89ab-cdef-0123-456789abcdef`:
+  `hronirs/0/1/2/3/4/5/6/7/-/8/9/a/b/-/c/d/e/f/-/0/1/2/3/-/4/5/6/7/8/9/a/b/c/d/e/f/index.md`.
+
+## Chapter folder contents
+
+Inside each chapter's directory:
+
+1. `index.md` (or another extension as needed) – the chapter text.
+2. `metadata.json` – stores metadata such as the chapter's UUID.
+
+## Forking paths
+
+`forking_path/` will contain CSV files with the reading order.
+Each row stores `position`, `prev_uuid`, and `uuid`.
+The row also includes a deterministic `fork_uuid` computed from those
+three pieces of data. This allows referencing individual branching events.
+
+## Steps to implement
+
+- [x] Create utilities to compute UUID v5 from chapter text.
+- [ ] Migrate existing chapters into `hronirs/` using their generated UUIDs.
+- [x] Write `metadata.json` for each chapter storing its UUID.
+- [ ] Generate initial `forking_path/canonical.csv` representing the current
+  reading order.
+- [ ] Update CLI commands to read and write chapters using the new structure.
+- [ ] Adjust tests and documentation accordingly.
+
+This approach keeps chapter identifiers stable even if positions change and
+lays the groundwork for scalable branching and deduplication.

--- a/hronir_encyclopedia/ratings.py
+++ b/hronir_encyclopedia/ratings.py
@@ -1,0 +1,48 @@
+import pandas as pd
+from pathlib import Path
+
+DEFAULT_ELO = 1500
+K_FACTOR = 32
+
+
+def _expected(rating_a: float, rating_b: float) -> float:
+    return 1 / (1 + 10 ** ((rating_b - rating_a) / 400))
+
+
+def record_vote(position: int, winner: str, loser: str, base: Path | str = "ratings") -> None:
+    """Record a literary duel result and update Elo ratings."""
+    base = Path(base)
+    base.mkdir(exist_ok=True)
+    csv_path = base / f"position_{position:03d}.csv"
+    if csv_path.exists():
+        df = pd.read_csv(csv_path)
+    else:
+        df = pd.DataFrame(columns=["chapter", "elo", "wins", "losses"])
+
+    for chapter in (winner, loser):
+        if chapter not in df["chapter"].values:
+            df = pd.concat([
+                df,
+                pd.DataFrame({
+                    "chapter": [chapter],
+                    "elo": [DEFAULT_ELO],
+                    "wins": [0],
+                    "losses": [0],
+                })
+            ], ignore_index=True)
+
+    w_idx = df.index[df["chapter"] == winner][0]
+    l_idx = df.index[df["chapter"] == loser][0]
+    w_rating = df.at[w_idx, "elo"]
+    l_rating = df.at[l_idx, "elo"]
+
+    expected_w = _expected(w_rating, l_rating)
+    expected_l = _expected(l_rating, w_rating)
+
+    df.at[w_idx, "elo"] = w_rating + K_FACTOR * (1 - expected_w)
+    df.at[l_idx, "elo"] = l_rating + K_FACTOR * (0 - expected_l)
+
+    df.at[w_idx, "wins"] += 1
+    df.at[l_idx, "losses"] += 1
+
+    df.to_csv(csv_path, index=False)

--- a/hronir_encyclopedia/storage.py
+++ b/hronir_encyclopedia/storage.py
@@ -1,0 +1,119 @@
+import json
+import uuid
+from pathlib import Path
+
+UUID_NAMESPACE = uuid.NAMESPACE_URL
+
+
+def compute_forking_uuid(position: int, prev_uuid: str, cur_uuid: str) -> str:
+    """Return deterministic UUID5 for a forking path entry."""
+    data = f"{position}:{prev_uuid}:{cur_uuid}"
+    return str(uuid.uuid5(UUID_NAMESPACE, data))
+
+
+def compute_uuid(text: str) -> str:
+    """Return deterministic UUID5 of the given text."""
+    return str(uuid.uuid5(UUID_NAMESPACE, text))
+
+
+def uuid_to_path(uuid_str: str, base: Path) -> Path:
+    """Split UUID characters into a directory tree under base."""
+    parts = list(uuid_str)
+    path = base
+    for c in parts:
+        path /= c
+    return path
+
+
+def store_chapter(chapter_file: Path, previous_uuid: str | None = None, base: Path | str = "hronirs") -> str:
+    """Store chapter_file content under UUID-based path and return UUID."""
+    base = Path(base)
+    text = chapter_file.read_text()
+    chapter_uuid = compute_uuid(text)
+    chapter_dir = uuid_to_path(chapter_uuid, base)
+    chapter_dir.mkdir(parents=True, exist_ok=True)
+
+    ext = chapter_file.suffix or ".md"
+    (chapter_dir / f"index{ext}").write_text(text)
+
+    meta = {"uuid": chapter_uuid}
+    if previous_uuid:
+        meta["previous_uuid"] = previous_uuid
+    (chapter_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
+    return chapter_uuid
+
+
+def is_valid_uuid_v5(value: str) -> bool:
+    """Return True if value is a valid UUIDv5."""
+    try:
+        u = uuid.UUID(value)
+        return u.version == 5
+    except ValueError:
+        return False
+
+
+def chapter_exists(uuid_str: str, base: Path | str = "hronirs") -> bool:
+    """Return True if a chapter directory exists for uuid_str."""
+    base = Path(base)
+    chapter_dir = uuid_to_path(uuid_str, base)
+    return any(chapter_dir.glob("index.*"))
+
+
+def validate_or_move(chapter_file: Path, base: Path | str = "hronirs") -> str:
+    """Ensure chapter_file resides under its UUID path. Move if necessary."""
+    base = Path(base)
+    text = chapter_file.read_text()
+    chapter_uuid = compute_uuid(text)
+    target_dir = uuid_to_path(chapter_uuid, base)
+    ext = chapter_file.suffix or ".md"
+    target_file = target_dir / f"index{ext}"
+    if chapter_file.resolve() != target_file.resolve():
+        target_dir.mkdir(parents=True, exist_ok=True)
+        chapter_file.replace(target_file)
+    meta_path = target_dir / "metadata.json"
+    if not meta_path.exists():
+        meta = {"uuid": chapter_uuid}
+        meta_path.write_text(json.dumps(meta, indent=2))
+    return chapter_uuid
+
+
+def audit_forking_csv(csv_path: Path, base: Path | str = "hronirs") -> None:
+    """Validate chapters referenced in a forking path CSV."""
+    import pandas as pd
+
+    base = Path(base)
+    df = pd.read_csv(csv_path)
+
+    # Normalise column names
+    cols = list(df.columns)
+    if "position" not in cols:
+        df.insert(0, "position", range(len(df)))
+        cols = ["position"] + cols
+    if "prev_uuid" not in cols:
+        df.rename(columns={cols[1]: "prev_uuid"}, inplace=True)
+    if "uuid" not in df.columns:
+        df.rename(columns={df.columns[2]: "uuid"}, inplace=True)
+
+    if "fork_uuid" not in df.columns:
+        df["fork_uuid"] = ""
+    if "undiscovered" not in df.columns:
+        df["undiscovered"] = False
+
+    changed = False
+    for idx, row in df.iterrows():
+        position = int(row["position"])
+        prev_uuid = str(row["prev_uuid"])
+        cur_uuid = str(row["uuid"])
+        fork_uuid = compute_forking_uuid(position, prev_uuid, cur_uuid)
+        if row.get("fork_uuid") != fork_uuid:
+            df.at[idx, "fork_uuid"] = fork_uuid
+            changed = True
+        prev_ok = is_valid_uuid_v5(prev_uuid) and chapter_exists(prev_uuid, base)
+        cur_ok = is_valid_uuid_v5(cur_uuid) and chapter_exists(cur_uuid, base)
+        if not (prev_ok and cur_ok):
+            df.at[idx, "undiscovered"] = True
+            changed = True
+
+    if changed:
+        df.to_csv(csv_path, index=False)
+


### PR DESCRIPTION
## Summary
- add simple Elo rating helper and `vote` CLI command
- clarify UUID storage plan and remove confusing metadata section
- show new `vote` command in Quickstart

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d72c245083259be95c15c0e5c69c