### PR TITLE
Add Gemini auto-vote utility and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ book/
 │   └── 02_b.md
 ├── book_index.json              # Detailed narrative tree
 ratings/
-└── position_002.csv             # Elo ratings per chapter position
+└── position_002.csv             # Recorded votes per chapter position
 ```
 
 ---
@@ -177,11 +177,28 @@ python -m hronir_encyclopedia.cli validate --chapter book/03/03_human.md
 # Submit human contribution to ranking system
 python -m hronir_encyclopedia.cli submit --chapter book/03/03_human.md --author "human"
 
+# Store chapter using UUID layout
+python -m hronir_encyclopedia.cli store book/03/03_human.md --prev 123e4567-e89b-12d3-a456-426614174000
+
+# Validate and repair stored chapters
+python -m hronir_encyclopedia.cli audit
+# Each forking entry receives a deterministic UUID
+
+# Automatically generate two chapters with Gemini and cast a vote
+python -m hronir_encyclopedia.cli autovote \
+  --position 1 \
+  --prev 123e4567-e89b-12d3-a456-426614174000 \
+  --voter 01234567-89ab-cdef-0123-456789abcdef
+# GEMINI_API_KEY must be set in your environment
+
 # Export the highest-ranked path as EPUB
 python -m hronir_encyclopedia.cli export --format epub --path canonical
 
 # Submit a vote with proof of work
-python -m hronir_encyclopedia.cli vote --position 1 --path "0->1" --hronirs key stone
+python -m hronir_encyclopedia.cli vote 
+  --position 1 
+  --voter 01234567-89ab-cdef-0123-456789abcdef 
+  --path "0->1" --hronirs keystone
 ```
 
 ## 🔏 Proof-of-Work Voting
@@ -193,9 +210,10 @@ For a deeper look at the rationale behind this system, see [docs/proof_of_work_v
 ### Vote on a literary duel:
 
 ```bash
-curl -X POST /vote \
-  -H "Content-Type: application/json" \
-  -d '{ "position": 3, "winner": "3_a", "loser": "3_b" }'
+python -m hronir_encyclopedia.cli vote \
+  --position 3 \
+  --voter 89abcdef-0123-4567-89ab-cdef01234567 \
+  --winner 3_a --loser 3_b
 ```
 
 ---

--- a/docs/proof_of_work_voting.md
+++ b/docs/proof_of_work_voting.md
@@ -13,9 +13,12 @@ In a system with limitless branching paths, it would be trivial to submit endles
 3. **Submit** the vote along with the two hr\u00f6nirs via the CLI:
 
    ```bash
-   python -m hronir_encyclopedia.cli vote --position 1 --path "0->1" --hronirs a b
+   python -m hronir_encyclopedia.cli vote \
+     --position 1 \
+     --voter 01234567-89ab-cdef-0123-456789abcdef \
+     --path "0->1" --hronirs a b
    ```
-4. The vote is recorded in `ratings/position_001.csv`. Each vote counts unless its forking path ends up with the greatest **distance** in the graph. The distance is calculated as the difference in path length from the current leader plus the path's ranking position. Paths with the maximum distance remain on record but their votes do not influence the standings.
+4. The vote is recorded in `ratings/position_001.csv`. Each row stores the voter uuid along with the winning and losing paths. The CSV uses three columns: `voter`, `winner`, and `loser`. Votes are tallied immediately unless their forking path has the greatest **distance** in the graph. Distance equals the difference in path length from the current leader plus the path's ranking position. Paths with the maximum distance remain recorded but their votes do not influence the standings.
 
 ## A Self-Expanding Canon
 

--- a/docs/uuid_structure_plan.md
+++ b/docs/uuid_structure_plan.md
@@ -1,0 +1,42 @@
+# Plan for UUID-based Chapter Storage
+
+This document outlines the proposed changes to store chapters using
+content-derived UUIDs rather than the current numeric structure.
+
+## Directory layout
+
+- `hronirs/` – root folder containing every chapter.
+- `forking_path/` – sequence of chapters that form narrative branches.
+- Each chapter will be referenced by a UUID v5 computed from its Markdown
+  contents.
+- To avoid large folder listings, each character of the UUID becomes a
+  directory level. Example for UUID
+  `01234567-89ab-cdef-0123-456789abcdef`:
+  `hronirs/0/1/2/3/4/5/6/7/-/8/9/a/b/-/c/d/e/f/-/0/1/2/3/-/4/5/6/7/8/9/a/b/c/d/e/f/index.md`.
+
+## Chapter folder contents
+
+Inside each chapter's directory:
+
+1. `index.md` (or another extension as needed) – the chapter text.
+2. `metadata.json` – stores metadata such as the chapter's UUID.
+
+## Forking paths
+
+`forking_path/` will contain CSV files with the reading order.
+Each row stores `position`, `prev_uuid`, and `uuid`.
+The row also includes a deterministic `fork_uuid` computed from those
+three pieces of data. This allows referencing individual branching events.
+
+## Steps to implement
+
+- [x] Create utilities to compute UUID v5 from chapter text.
+- [ ] Migrate existing chapters into `hronirs/` using their generated UUIDs.
+- [x] Write `metadata.json` for each chapter storing its UUID.
+- [ ] Generate initial `forking_path/canonical.csv` representing the current
+  reading order.
+- [ ] Update CLI commands to read and write chapters using the new structure.
+- [ ] Adjust tests and documentation accordingly.
+
+This approach keeps chapter identifiers stable even if positions change and
+lays the groundwork for scalable branching and deduplication.

--- a/hronir_encyclopedia/gemini_util.py
+++ b/hronir_encyclopedia/gemini_util.py
@@ -1,0 +1,51 @@
+import os
+import requests
+from pathlib import Path
+import pandas as pd
+from . import storage, ratings
+
+API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent"
+
+
+def _gemini_request(prompt: str) -> str:
+    key = os.getenv("GEMINI_API_KEY")
+    if not key:
+        raise RuntimeError("GEMINI_API_KEY not set")
+    url = f"{API_URL}?key={key}"
+    payload = {"contents": [{"parts": [{"text": prompt}]}]}
+    r = requests.post(url, json=payload)
+    r.raise_for_status()
+    data = r.json()
+    return data["candidates"][0]["content"]["parts"][0]["text"]
+
+
+def generate_chapter(prompt: str, prev_uuid: str | None = None) -> str:
+    """Generate a chapter with Gemini and store it."""
+    text = _gemini_request(prompt)
+    return storage.store_chapter_text(text, previous_uuid=prev_uuid)
+
+
+def append_fork(csv_file: Path, position: int, prev_uuid: str, uuid: str) -> str:
+    csv_file.parent.mkdir(parents=True, exist_ok=True)
+    fork_uuid = storage.compute_forking_uuid(position, prev_uuid, uuid)
+    if csv_file.exists():
+        df = pd.read_csv(csv_file)
+    else:
+        df = pd.DataFrame(columns=["position", "prev_uuid", "uuid", "fork_uuid"])
+    df = pd.concat([
+        df,
+        pd.DataFrame([{"position": position, "prev_uuid": prev_uuid, "uuid": uuid, "fork_uuid": fork_uuid}])
+    ], ignore_index=True)
+    df.to_csv(csv_file, index=False)
+    return fork_uuid
+
+
+def auto_vote(position: int, prev_uuid: str, voter: str) -> str:
+    """Generate winner and loser chapters and record a vote."""
+    winner_uuid = generate_chapter(f"Winner for position {position}", prev_uuid)
+    loser_uuid = generate_chapter(f"Loser for position {position}", prev_uuid)
+    fork_csv = Path("forking_path/auto.csv")
+    append_fork(fork_csv, position, prev_uuid, winner_uuid)
+    append_fork(fork_csv, position, prev_uuid, loser_uuid)
+    ratings.record_vote(position, voter, winner_uuid, loser_uuid)
+    return winner_uuid

--- a/hronir_encyclopedia/ratings.py
+++ b/hronir_encyclopedia/ratings.py
@@ -1,0 +1,23 @@
+import uuid
+from pathlib import Path
+import pandas as pd
+
+
+def record_vote(position: int, voter: str, winner: str, loser: str, base: Path | str = "ratings") -> None:
+    """Append a vote to the CSV for the given position."""
+    base = Path(base)
+    base.mkdir(exist_ok=True)
+    csv_path = base / f"position_{position:03d}.csv"
+
+    row = {
+        "uuid": str(uuid.uuid4()),
+        "voter": voter,
+        "winner": winner,
+        "loser": loser,
+    }
+    if csv_path.exists():
+        df = pd.read_csv(csv_path)
+        df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
+    else:
+        df = pd.DataFrame([row])
+    df.to_csv(csv_path, index=False)

--- a/hronir_encyclopedia/storage.py
+++ b/hronir_encyclopedia/storage.py
@@ -1,0 +1,122 @@
+import json
+import uuid
+from pathlib import Path
+
+UUID_NAMESPACE = uuid.NAMESPACE_URL
+
+
+def compute_forking_uuid(position: int, prev_uuid: str, cur_uuid: str) -> str:
+    """Return deterministic UUID5 for a forking path entry."""
+    data = f"{position}:{prev_uuid}:{cur_uuid}"
+    return str(uuid.uuid5(UUID_NAMESPACE, data))
+
+
+def compute_uuid(text: str) -> str:
+    """Return deterministic UUID5 of the given text."""
+    return str(uuid.uuid5(UUID_NAMESPACE, text))
+
+
+def uuid_to_path(uuid_str: str, base: Path) -> Path:
+    """Split UUID characters into a directory tree under base."""
+    parts = list(uuid_str)
+    path = base
+    for c in parts:
+        path /= c
+    return path
+
+
+def store_chapter(chapter_file: Path, previous_uuid: str | None = None, base: Path | str = "hronirs") -> str:
+    """Store chapter_file content under UUID-based path and return UUID."""
+    text = chapter_file.read_text()
+    return store_chapter_text(text, previous_uuid, base, ext=chapter_file.suffix or ".md")
+
+
+def store_chapter_text(text: str, previous_uuid: str | None = None, base: Path | str = "hronirs", *, ext: str = ".md") -> str:
+    """Store the given text under a UUID path and return the UUID."""
+    base = Path(base)
+    chapter_uuid = compute_uuid(text)
+    chapter_dir = uuid_to_path(chapter_uuid, base)
+    chapter_dir.mkdir(parents=True, exist_ok=True)
+
+    (chapter_dir / f"index{ext}").write_text(text)
+
+    meta = {"uuid": chapter_uuid}
+    if previous_uuid:
+        meta["previous_uuid"] = previous_uuid
+    (chapter_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
+    return chapter_uuid
+
+
+def is_valid_uuid_v5(value: str) -> bool:
+    """Return True if value is a valid UUIDv5."""
+    try:
+        u = uuid.UUID(value)
+        return u.version == 5
+    except ValueError:
+        return False
+
+
+def chapter_exists(uuid_str: str, base: Path | str = "hronirs") -> bool:
+    """Return True if a chapter directory exists for uuid_str."""
+    base = Path(base)
+    chapter_dir = uuid_to_path(uuid_str, base)
+    return any(chapter_dir.glob("index.*"))
+
+
+def validate_or_move(chapter_file: Path, base: Path | str = "hronirs") -> str:
+    """Ensure chapter_file resides under its UUID path. Move if necessary."""
+    base = Path(base)
+    text = chapter_file.read_text()
+    chapter_uuid = compute_uuid(text)
+    target_dir = uuid_to_path(chapter_uuid, base)
+    ext = chapter_file.suffix or ".md"
+    target_file = target_dir / f"index{ext}"
+    if chapter_file.resolve() != target_file.resolve():
+        target_dir.mkdir(parents=True, exist_ok=True)
+        chapter_file.replace(target_file)
+    meta_path = target_dir / "metadata.json"
+    if not meta_path.exists():
+        meta = {"uuid": chapter_uuid}
+        meta_path.write_text(json.dumps(meta, indent=2))
+    return chapter_uuid
+
+
+def audit_forking_csv(csv_path: Path, base: Path | str = "hronirs") -> None:
+    """Validate chapters referenced in a forking path CSV."""
+    import pandas as pd
+
+    base = Path(base)
+    df = pd.read_csv(csv_path)
+
+    # Normalise column names
+    cols = list(df.columns)
+    if "position" not in cols:
+        df.insert(0, "position", range(len(df)))
+        cols = ["position"] + cols
+    if "prev_uuid" not in cols:
+        df.rename(columns={cols[1]: "prev_uuid"}, inplace=True)
+    if "uuid" not in df.columns:
+        df.rename(columns={df.columns[2]: "uuid"}, inplace=True)
+
+    if "fork_uuid" not in df.columns:
+        df["fork_uuid"] = ""
+    if "undiscovered" not in df.columns:
+        df["undiscovered"] = False
+
+    changed = False
+    for idx, row in df.iterrows():
+        position = int(row["position"])
+        prev_uuid = str(row["prev_uuid"])
+        cur_uuid = str(row["uuid"])
+        fork_uuid = compute_forking_uuid(position, prev_uuid, cur_uuid)
+        if row.get("fork_uuid") != fork_uuid:
+            df.at[idx, "fork_uuid"] = fork_uuid
+            changed = True
+        prev_ok = is_valid_uuid_v5(prev_uuid) and chapter_exists(prev_uuid, base)
+        cur_ok = is_valid_uuid_v5(cur_uuid) and chapter_exists(cur_uuid, base)
+        if not (prev_ok and cur_ok):
+            df.at[idx, "undiscovered"] = True
+            changed = True
+
+    if changed:
+        df.to_csv(csv_path, index=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click
 pandas
+requests


### PR DESCRIPTION
## Summary
- store chapters from text with `store_chapter_text`
- provide Gemini-based utility for generating chapters and casting votes
- expose new `autovote` CLI command
- document `autovote` in README
- add `requests` to requirements
- note `GEMINI_API_KEY` environment variable

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843733ee820832580637685cfc2f0d7