### PR TITLE
Add data cleanup helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ python -m hronir_encyclopedia.cli store book/03/03_human.md --prev 123e4567-e89b
 python -m hronir_encyclopedia.cli audit
 # Each forking entry receives a deterministic UUID
 
+# Remove invalid hrönirs, forking paths or votes
+python -m hronir_encyclopedia.cli clean --git
+
 # Automatically generate two chapters with Gemini and cast a vote
 python -m hronir_encyclopedia.cli autovote \
   --position 1 \

--- a/tests/test_storage_and_votes.py
+++ b/tests/test_storage_and_votes.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+import subprocess
 from pathlib import Path
 
 import pandas as pd
@@ -47,4 +48,86 @@ def test_auto_vote_records_votes(monkeypatch, tmp_path):
 
     df = pd.read_csv(Path("ratings/position_001.csv"))
     assert len(df) == 10
+
+
+def test_clean_functions(tmp_path):
+    base = tmp_path / "hronirs"
+    uid1 = storage.store_chapter_text("good", base=base)
+    uid2 = storage.store_chapter_text("better", base=base)
+
+    fake = storage.store_chapter_text("fake", base=base)
+    fake_dir = storage.uuid_to_path(fake, base)
+    (fake_dir / "index.md").write_text("tampered")
+
+    assert storage.chapter_exists(fake, base)
+    removed = storage.purge_fake_hronirs(base=base)
+    assert removed == 1
+    assert storage.chapter_exists(uid1, base)
+    assert not storage.chapter_exists(fake, base)
+
+    fork_csv = tmp_path / "fork.csv"
+    valid_row = {
+        "position": 1,
+        "prev_uuid": uid1,
+        "uuid": uid2,
+        "fork_uuid": storage.compute_forking_uuid(1, uid1, uid2),
+    }
+    invalid_row = {
+        "position": 1,
+        "prev_uuid": uid1,
+        "uuid": fake,
+        "fork_uuid": "bad",
+    }
+    pd.DataFrame([valid_row, invalid_row]).to_csv(fork_csv, index=False)
+    removed = storage.purge_fake_forking_csv(fork_csv, base=base)
+    assert removed == 1
+    df = pd.read_csv(fork_csv)
+    assert len(df) == 1
+
+    rating_csv = tmp_path / "rating.csv"
+    rows = [
+        {
+            "uuid": str(uuid.uuid4()),
+            "voter": "fork1",
+            "winner": uid1,
+            "loser": uid2,
+        },
+        {
+            "uuid": str(uuid.uuid4()),
+            "voter": "fork1",
+            "winner": uid1,
+            "loser": uid2,
+        },
+        {
+            "uuid": str(uuid.uuid4()),
+            "voter": "fork2",
+            "winner": uid1,
+            "loser": fake,
+        },
+    ]
+    pd.DataFrame(rows).to_csv(rating_csv, index=False)
+    removed = storage.purge_fake_votes_csv(rating_csv, base=base)
+    assert removed == 2
+    df = pd.read_csv(rating_csv)
+    assert len(df) == 1
+
+
+def test_clean_git_prunes_from_branch(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True)
+
+    base = Path("hronirs")
+    uid = storage.store_chapter_text("data", base=base)
+    bad = storage.store_chapter_text("bad", base=base)
+    bad_dir = storage.uuid_to_path(bad, base)
+    (bad_dir / "index.md").write_text("tampered")
+
+    subprocess.run(["git", "add", "-A"], check=True)
+    subprocess.run(["git", "commit", "-m", "init"], check=True)
+
+    from hronir_encyclopedia import cli
+    cli.main(["clean", "--git"])
+
+    ls_files = subprocess.check_output(["git", "ls-files"], text=True)
+    assert str(bad_dir / "index.md") not in ls_files
 


### PR DESCRIPTION
## Summary
- implement `purge_fake_hronirs`, `purge_fake_forking_csv`, and `purge_fake_votes_csv`
- add `clean` CLI command
- document `clean` in README
- test cleaning functions
- expose a new `--git` option to remove deleted files from the git index

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843a186c4d083258eb0a392b5aee7f7