### PR TITLE
Fix README installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Among infinite possibilities, one version will ultimately prove itself authentic
 
 ```bash
 git clone https://github.com/franklinbaldo/hronir
-cd hronir_encyclopedia
+cd hronir
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
## Summary
- correct the repository path in installation instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f341cbe2083259852a57b00346b88