### PR TITLE
Implement temporary SQLite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ python -m hronir_encyclopedia.cli autovote \
   --voter 01234567-89ab-cdef-0123-456789abcdef
 # GEMINI_API_KEY must be set in your environment
 
+# These commands load ratings and forking_path CSV files into a temporary
+# SQLite database. Changes are written back to CSV when the command finishes.
+
 # Export the highest-ranked path as EPUB
 python -m hronir_encyclopedia.cli export --format epub --path canonical
 

--- a/hronir_encyclopedia/cli.py
+++ b/hronir_encyclopedia/cli.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import subprocess
 from pathlib import Path
-from . import storage, ratings, gemini_util
+from . import storage, ratings, gemini_util, database
 
 
 def _placeholder_handler(name):
@@ -39,7 +39,10 @@ def _cmd_store(args):
 
 
 def _cmd_vote(args):
-    ratings.record_vote(args.position, args.voter, args.winner, args.loser)
+    with database.open_database() as conn:
+        ratings.record_vote(
+            args.position, args.voter, args.winner, args.loser, conn=conn
+        )
     print("vote recorded")
 
 
@@ -55,7 +58,8 @@ def _cmd_audit(args):
 
 
 def _cmd_auto_vote(args):
-    gemini_util.auto_vote(args.position, args.prev, args.voter)
+    with database.open_database() as conn:
+        gemini_util.auto_vote(args.position, args.prev, args.voter, conn=conn)
     print("auto vote recorded")
 
 

--- a/hronir_encyclopedia/database.py
+++ b/hronir_encyclopedia/database.py
@@ -1,0 +1,95 @@
+import sqlite3
+from pathlib import Path
+import pandas as pd
+import os
+import tempfile
+
+_CONNECTION_MAP: dict[int, dict[str, Path]] = {}
+
+class CsvDatabase:
+    """Context manager loading CSV files into an SQLite database."""
+
+    def __init__(self, ratings_dir: Path | str = "ratings", fork_dir: Path | str = "forking_path", filename: str | None = None):
+        self.ratings_dir = Path(ratings_dir)
+        self.fork_dir = Path(fork_dir)
+        self.filename = filename or ":memory:"
+        self._conn: sqlite3.Connection | None = None
+        self._mapping: dict[str, Path] = {}
+
+    def _load_csv(self, csv: Path) -> None:
+        table = csv.stem
+        if csv.exists() and csv.stat().st_size:
+            df = pd.read_csv(csv)
+        else:
+            df = pd.DataFrame()
+        df.to_sql(table, self._conn, index=False, if_exists="replace")
+        self._mapping[table] = csv
+
+    def _load(self) -> None:
+        self.ratings_dir.mkdir(exist_ok=True)
+        self.fork_dir.mkdir(exist_ok=True)
+        for csv in self.ratings_dir.glob("*.csv"):
+            self._load_csv(csv)
+        for csv in self.fork_dir.glob("*.csv"):
+            self._load_csv(csv)
+
+    def __enter__(self) -> sqlite3.Connection:
+        if self.filename == ":memory:":
+            self._conn = sqlite3.connect(self.filename)
+        else:
+            self._conn = sqlite3.connect(self.filename)
+        self._load()
+        _CONNECTION_MAP[id(self._conn)] = {
+            "mapping": self._mapping,
+            "ratings_dir": self.ratings_dir,
+            "fork_dir": self.fork_dir,
+        }
+        return self._conn
+
+    def commit_to_csv(self) -> None:
+        if not self._conn:
+            return
+        commit_to_csv(self._conn)
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            self.commit_to_csv()
+        finally:
+            if self._conn:
+                conn_id = id(self._conn)
+                self._conn.close()
+                if conn_id in _CONNECTION_MAP:
+                    del _CONNECTION_MAP[conn_id]
+                if self.filename and self.filename != ":memory:" and os.path.exists(self.filename):
+                    os.remove(self.filename)
+
+
+def commit_to_csv(conn: sqlite3.Connection) -> None:
+    """Write loaded tables back to their original CSV files."""
+    info = _CONNECTION_MAP.get(id(conn))
+    if not info:
+        return
+    mapping = info.get("mapping", {})
+    ratings_dir = Path(info.get("ratings_dir", "ratings"))
+    fork_dir = Path(info.get("fork_dir", "forking_path"))
+    cur = conn.cursor()
+    tables = [row[0] for row in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    for table in tables:
+        csv = mapping.get(table)
+        if not csv:
+            if table.startswith("position_"):
+                csv = ratings_dir / f"{table}.csv"
+            else:
+                csv = fork_dir / f"{table}.csv"
+        df = pd.read_sql_query(f"SELECT * FROM `{table}`", conn)
+        csv.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(csv, index=False)
+
+
+def open_database(temp_file: bool = False, ratings_dir: Path | str = "ratings", fork_dir: Path | str = "forking_path") -> CsvDatabase:
+    """Return CsvDatabase context manager."""
+    if temp_file:
+        fd, path = tempfile.mkstemp(suffix=".sqlite")
+        os.close(fd)
+        return CsvDatabase(ratings_dir, fork_dir, filename=path)
+    return CsvDatabase(ratings_dir, fork_dir, filename=":memory:")

--- a/hronir_encyclopedia/ratings.py
+++ b/hronir_encyclopedia/ratings.py
@@ -1,10 +1,37 @@
 import uuid
 from pathlib import Path
+from typing import Optional
 import pandas as pd
+import sqlite3
 
 
-def record_vote(position: int, voter: str, winner: str, loser: str, base: Path | str = "ratings") -> None:
-    """Append a vote to the CSV for the given position."""
+def record_vote(
+    position: int,
+    voter: str,
+    winner: str,
+    loser: str,
+    base: Path | str = "ratings",
+    conn: Optional[sqlite3.Connection] = None,
+) -> None:
+    """Append a vote to the ratings table."""
+    if conn is not None:
+        table = f"position_{position:03d}"
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS `{table}` (
+                uuid TEXT,
+                voter TEXT,
+                winner TEXT,
+                loser TEXT
+            )
+            """
+        )
+        conn.execute(
+            f"INSERT INTO `{table}` (uuid, voter, winner, loser) VALUES (?, ?, ?, ?)",
+            (str(uuid.uuid4()), voter, winner, loser),
+        )
+        return
+
     base = Path(base)
     base.mkdir(exist_ok=True)
     csv_path = base / f"position_{position:03d}.csv"


### PR DESCRIPTION
## Summary
- add SQLite database loader utilities
- switch vote and autovote commands to use database
- allow ratings and fork helpers to operate on a connection
- support optional DB connections for helper functions
- document workflow and test coverage

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f342a17f483259a94e45d4698c1ae