### PR TITLE
Restore nested layout with clean UUIDs

### DIFF
--- a/docs/uuid_structure_plan.md
+++ b/docs/uuid_structure_plan.md
@@ -9,10 +9,9 @@ content-derived UUIDs rather than the current numeric structure.
 - `forking_path/` – sequence of chapters that form narrative branches.
 - Each chapter will be referenced by a UUID v5 computed from its Markdown
   contents.
-- To avoid large folder listings, each character of the UUID becomes a
-  directory level. Example for UUID
-  `01234567-89ab-cdef-0123-456789abcdef`:
-  `the_library/0/1/2/3/4/5/6/7/-/8/9/a/b/-/c/d/e/f/-/0/1/2/3/-/4/5/6/7/8/9/a/b/c/d/e/f/index.md`.
+- To avoid large folder listings, each character of the UUID (with dashes removed)
+  becomes a directory level. Example for UUID `01234567-89ab-cdef-0123-456789abcdef`:
+  `the_library/0/1/2/3/4/5/6/7/8/9/a/b/c/d/e/f/0/1/2/3/4/5/6/7/8/9/a/b/c/d/e/f/index.md`.
 
 ## Chapter folder contents
 

--- a/hronir_encyclopedia/storage.py
+++ b/hronir_encyclopedia/storage.py
@@ -19,10 +19,10 @@ def compute_uuid(text: str) -> str:
 
 
 def uuid_to_path(uuid_str: str, base: Path) -> Path:
-    """Split UUID characters into a directory tree under base."""
-    parts = list(uuid_str)
+    """Return nested path for uuid_str under base using a hyphenless UUID."""
+    uuid_clean = uuid_str.replace("-", "")
     path = base
-    for c in parts:
+    for c in uuid_clean:
         path /= c
     return path
 


### PR DESCRIPTION
## Summary
- revert to nested directory layout for chapters
- strip dashes from UUIDs when constructing paths
- document the hyphenless nested structure

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68507036ae9c8325a189f6dd3763bc38