### PR TITLE
Collect metadata list before purging fake chapters

### DIFF
--- a/hronir_encyclopedia/storage.py
+++ b/hronir_encyclopedia/storage.py
@@ -179,7 +179,8 @@ def purge_fake_hronirs(base: Path | str = "the_library") -> int:
     """Remove chapters whose metadata or path UUID doesn't match their text."""
     base = Path(base)
     removed = 0
-    for meta in base.rglob("metadata.json"):
+    metas = list(base.rglob("metadata.json"))
+    for meta in metas:
         chapter_dir = meta.parent
         try:
             data = json.loads(meta.read_text())


### PR DESCRIPTION
## Summary
- iterate over `metadata.json` files using a pre-collected list
- ensure `purge_fake_hronirs` works correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549e55bf248325812bbb9847d8a65d