### PR TITLE
Implement synthesize and ranking commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,4 +29,21 @@ Thank you for your interest in helping expand this labyrinthine narrative. This 
 8. **Review** happens publicly; maintainers may request adjustments to tone or structure.
 9. Once approved, your chapter is merged and enters the Elo ranking system.
 
+### Helpful CLI commands
+
+Check the current standings for a chapter:
+
+```bash
+python -m hronir_encyclopedia.cli ranking --position 1
+```
+
+Generate two variants and cast a vote automatically:
+
+```bash
+python -m hronir_encyclopedia.cli synthesize \
+  --position 1 \
+  --prev <previous_uuid> \
+  --voter <fork_uuid>
+```
+
 Happy writing—may your version prove itself the inevitable one.

--- a/README.md
+++ b/README.md
@@ -163,14 +163,13 @@ ratings/
 
 ## ⚙️ Quickstart CLI Usage
 
-### Generate a new chapter from the accumulated narrative space:
+### Generate new chapters and cast a vote automatically:
 
 ```bash
-# Generate a single variant for Chapter 3
-python -m hronir_encyclopedia.cli synthesize --position 3 --variant_id 3_a
-
-# Generate multiple variants at once
-python -m hronir_encyclopedia.cli synthesize --position 3 --variants 3
+python -m hronir_encyclopedia.cli synthesize \
+  --position 3 \
+  --prev 123e4567-e89b-12d3-a456-426614174000 \
+  --voter 01234567-89ab-cdef-0123-456789abcdef
 
 # View the current narrative tree (prints a simple list for now)
 python -m hronir_encyclopedia.cli tree

--- a/tests/test_ratings_ranking.py
+++ b/tests/test_ratings_ranking.py
@@ -1,0 +1,19 @@
+from hronir_encyclopedia import ratings, database
+
+
+def test_get_ranking(tmp_path):
+    base = tmp_path / "ratings"
+    fork_dir = tmp_path / "forking"
+    with database.open_database(ratings_dir=base, fork_dir=fork_dir) as conn:
+        ratings.record_vote(1, "v1", "a", "b", conn=conn)
+        ratings.record_vote(1, "v2", "a", "c", conn=conn)
+        ratings.record_vote(1, "v3", "b", "a", conn=conn)
+
+    df = ratings.get_ranking(1, base=base)
+    assert list(df["chapter"]) == ["a", "b", "c"]
+    row_a = df[df["chapter"] == "a"].iloc[0]
+    row_b = df[df["chapter"] == "b"].iloc[0]
+    row_c = df[df["chapter"] == "c"].iloc[0]
+    assert row_a["wins"] == 2 and row_a["losses"] == 1
+    assert row_b["wins"] == 1 and row_b["losses"] == 1
+    assert row_c["wins"] == 0 and row_c["losses"] == 1


### PR DESCRIPTION
## Summary
- implement `synthesize` command that auto-generates two chapters and casts a vote
- add `ranking` command to display wins and losses
- provide `ratings.get_ranking` helper
- document new commands in README and CONTRIBUTING
- add tests for the ranking logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549e51962883259454b7d0762ba028