### PR TITLE
Clarify fork_uuid proof-of-work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Committing these hrönirs offers several benefits:
 ## Section 2: Active Participation in Canon Evolution
 
 Beyond simply generating content for testing or examples, agents (especially automated ones designed for ongoing maintenance or evolution of the encyclopedia) are encouraged to actively participate in the core mechanics of the Hrönir Encyclopedia.
+Automated workflows can use the `synthesize` command to perform all three acts at once—generating hrönirs, writing the forking path entry, and casting the corresponding vote with the new `fork_uuid`.
 
 ### Expanded Expectations for Active Agents:
 

--- a/BUSINESS_RULES.md
+++ b/BUSINESS_RULES.md
@@ -24,11 +24,12 @@ This table defines the fundamental rules, principles, and constraints that gover
 
 | ID    | Rule Name                      | Description                                                                                                                                                                                                                          |
 | :---- | :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SC.1  | Proof-of-Work for Voting       | Voting is not a free action; it is an act of contribution. To vote, a participant must first expand the narrative possibilities, typically by generating new hrönirs and forking paths.                                                 |
+| SC.1  | Proof-of-Work for Voting       | Every vote **must** originate from a new row in `forking_path`. Creating this entry links valid hrönirs and yields a unique `fork_uuid` that acts as the voter identity and proof of work.
 | SC.2  | Vote Record Structure          | Votes are recorded in `.csv` files within the `ratings/` directory. Each record **must** contain a unique `uuid` (for the vote itself), a `voter`, a `winner` (hrönir UUID), and a `loser` (hrönir UUID).                              |
 | SC.3  | Voter Identity (Fork UUID)     | The `voter` field in a vote record **must** be the `fork_uuid` of a valid, existing forking path. A vote is cast "as" a specific narrative branch.                                                                                     |
 | SC.4  | One Vote per Voter per Position| A single `voter` (`fork_uuid`) may only cast **one vote** per position. Subsequent votes from the same `fork_uuid` for the same position are invalid.                                                                                   |
 | SC.5  | Vote Validity Conditions       | A vote is only valid if its `voter` is a valid `fork_uuid`, its `winner` and `loser` point to valid hrönirs, and the voter has not already voted for that position. Invalid votes are subject to automated purging.                      |
+| SC.6  | Canonização por Consenso | A versão canônica do livro é determinada periodicamente através do comando `consolidate_book`. Para cada posição, o hrönir com a maior pontuação Elo é copiado para `book/` e `book/book_index.json`. |
 
 ### Generation & Contribution (Agents)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,6 @@ Generate two variants and cast a vote automatically:
 python -m hronir_encyclopedia.cli synthesize \
   --position 1 \
   --prev <previous_uuid> \
-  --voter <fork_uuid>
 ```
 
 Happy writing—may your version prove itself the inevitable one.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ ratings/
 uv run python -m hronir_encyclopedia.cli synthesize \
   --position 3 \
   --prev 123e4567-e89b-12d3-a456-426614174000 \
-  --voter 01234567-89ab-cdef-0123-456789abcdef
 
 # View the current narrative tree (prints a simple list for now)
 uv run python -m hronir_encyclopedia.cli tree
@@ -207,13 +206,6 @@ uv run python -m hronir_encyclopedia.cli audit
 # Remove invalid hrönirs, forking paths or votes
 uv run python -m hronir_encyclopedia.cli clean --git
 
-# Automatically generate two chapters with Gemini and cast a vote
-uv run python -m hronir_encyclopedia.cli autovote \
-  --position 1 \
-  --prev 123e4567-e89b-12d3-a456-426614174000 \
-  --voter 01234567-89ab-cdef-0123-456789abcdef
-# Requires GEMINI_API_KEY in your .env file
-
 # These commands load ratings and forking_path CSV files into a temporary
 # SQLite database via SQLAlchemy. Changes are written back to CSV when the
 # command finishes.
@@ -230,9 +222,7 @@ uv run python -m hronir_encyclopedia.cli vote \
 
 ## 🔏 Proof-of-Work Voting
 
-Each vote must present a new forking path accompanied by two undiscovered hrönirs. This ingenious proof-of-work not only protects the ranking system from frivolous votes, it actively expands the encyclopedia's universe. Votes are tallied immediately unless their forking path has the greatest **distance** in the graph. Distance equals the difference in path length from the current leader plus the path's ranking position. Paths with the maximum distance remain recorded but their votes do not affect the rankings.
-
-For a deeper look at the rationale behind this system, see [docs/proof_of_work_voting.md](docs/proof_of_work_voting.md).
+Voting requires proof that you expanded the narrative. First create hrönirs with `store` and connect them via a new row in `forking_path/`. The resulting `fork_uuid` from that row is your voting identity. Use it with `vote` to choose a winner and loser. See [docs/proof_of_work_voting.md](docs/proof_of_work_voting.md) for details.
 
 ### Vote on a literary duel:
 

--- a/docs/proof_of_work_voting.md
+++ b/docs/proof_of_work_voting.md
@@ -1,31 +1,21 @@
 # Proof-of-Work Voting
 
-The Hr\u00f6nir Encyclopedia adopts a novel proof-of-work mechanism to keep its evolving canon free from spam while simultaneously enriching the narrative universe. This process turns each vote into a creative act.
+Voting in The Hrönir Encyclopedia is inseparable from contributing new narrative material. Each vote must prove that the voter expanded the story.
 
-## Why Proof of Work?
+## Ato 1: Criação (O Trabalho)
+Generate one or more hrönirs and store them using the `store` command. Every stored hrönir references a `prev_uuid` so the narrative chain remains intact.
 
-In a system with limitless branching paths, it would be trivial to submit endless votes for a favorite chapter. By requiring each vote to include new hr\u00f6nirs and a unique path, the system ensures that only participants who meaningfully contribute can influence the rankings. Every vote must push the encyclopedia forward.
+## Ato 2: Conexão (A Prova)
+Create a new entry in `forking_path/yu-tsun.csv` linking a `prev_uuid` to the newly stored hrönir's `uuid`. This row deterministically generates a `fork_uuid` which serves as your proof of work.
 
-## How It Works
+## Ato 3: Votação (O Uso da Prova)
+Use the `vote` command with the generated `fork_uuid` to choose between competing hrönirs:
 
-1. **Discover** two new hr\u00f6nirs that do not yet appear in `the_library/index.txt`.
-2. **Forge** a new forking path that has not been used before.
-3. **Submit** the vote along with the two hr\u00f6nirs via the CLI:
+```bash
+python -m hronir_encyclopedia.cli vote \
+  --position 1 \
+  --voter <fork_uuid> \
+  --winner <uuid> --loser <uuid>
+```
 
-   ```bash
-   python -m hronir_encyclopedia.cli vote \
-     --position 1 \
-     --voter 01234567-89ab-cdef-0123-456789abcdef \
-     --path "0->1" --hronirs a b
-   ```
-4. The vote is recorded in `ratings/position_001.csv`. Each row stores the voter uuid along with the winning and losing paths. The CSV uses three columns: `voter`, `winner`, and `loser`. Votes are tallied immediately unless their forking path has the greatest **distance** in the graph. Distance equals the difference in path length from the current leader plus the path's ranking position. Paths with the maximum distance remain recorded but their votes do not influence the standings.
-
-## A Self-Expanding Canon
-
-This ingenious mechanism transforms the act of voting into an engine of discovery. New hr\u00f6nirs fill the index, unexplored branches populate the narrative tree, and frivolous votes are thwarted without heavy moderation. The encyclopedia rewards readers who blaze new trails and share their findings with the community.
-
-## Checking Your Work
-
-You can inspect your local `ratings` directory to see where your path currently ranks. When your path reaches the top position for that chapter, the stored vote activates and influences the overall canon.
-
-The proof-of-work design elegantly balances participation and curation, ensuring the Hr\u00f6nir Encyclopedia grows in both breadth and depth.
+The system validates the `fork_uuid` and ensures it has not been used previously at that position. By tying each vote to a real forking path, the encyclopedia grows organically while remaining resistant to spam.


### PR DESCRIPTION
## Summary
- document synthesize without explicit voter
- remove outdated autovote example
- rewrite proof-of-work instructions
- clarify synthesize workflow in AGENTS guidelines
- refine business rules for voting

## Testing
- `pip install .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685692dde2b883259766d3a5cb589b79