### PR TITLE
Refactor: Unify architecture and complete core tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,39 +34,45 @@ Thank you for your interest in helping expand this labyrinthine narrative. This 
 
 Remember to use `uv run` before `python -m hronir_encyclopedia.cli` if you are using the `uv` environment, as shown in the examples below.
 
-Check the current Elo rankings for a chapter position:
+Check the current Elo rankings for forks at a chapter position:
 ```bash
 uv run python -m hronir_encyclopedia.cli ranking --position 1
 ```
 
-To participate in voting (after obtaining a `fork_uuid` as described in `docs/proof_of_work_voting.md`):
+To participate in the "Tribunal of the Future" (after creating a new hrönir and its `fork_uuid` at position `N`):
 
-1.  Discover the Duelo de Máxima Entropia for a position:
+1.  **Start a Judgment Session:**
+    Use your new `fork_uuid` (from position `N`) to start a session. This provides a `session_id` and a dossier of duels for prior positions.
     ```bash
-    uv run python -m hronir_encyclopedia.cli get-duel --position 1
-    ```
-    This will output JSON indicating the `fork_A` (e.g., `"fork_uuid_A..."`) and `fork_B` (e.g., `"fork_uuid_B..."`) for the duel of forks.
-
-2.  Cast your vote for the presented duel of forks:
-    ```bash
-    uv run python -m hronir_encyclopedia.cli vote \
-      --position 1 \
-      --voter-fork-uuid <your_pow_fork_uuid> \
-      --winner-fork-uuid <fork_A_uuid_from_get_duel> \
-      --loser-fork-uuid <fork_B_uuid_from_get_duel>
+    # Example: Your new fork at position N=3 is fork_N_uuid
+    uv run python -m hronir_encyclopedia.cli session start \
+      --position 3 \
+      --fork-uuid <your_fork_N_uuid>
     ```
 
-Generate two new hrönir variants from a predecessor and record an initial assessment (this is mainly for automated agents but can be used manually; it does not bypass the `get-duel` requirement for general voting):
-```bash
-uv run python -m hronir_encyclopedia.cli synthesize \
-  --position 1 \
-  --prev <previous_uuid>
-```
+2.  **Deliberate and Form Veredicts (Offline):**
+    Review the dossier. Decide which duels to vote on and select winners.
 
-Validate and store your own new chapter variant:
+3.  **Commit Your Veredicts:**
+    Submit your veredicts using the `session_id`.
+    ```bash
+    # Example: Committing veredicts for positions 2 and 0
+    uv run python -m hronir_encyclopedia.cli session commit \
+      --session-id <your_session_id> \
+      --verdicts '{"2": "winning_fork_for_pos2", "0": "winning_fork_for_pos0"}'
+    ```
+    Refer to `README.md` for more details on the session workflow.
+
+Validate and store your own new chapter variant (this is how you get a `fork_uuid` to start a session):
 ```bash
+# First, validate the content (optional, but good practice)
 uv run python -m hronir_encyclopedia.cli validate --chapter drafts/01_my_variant.md
-uv run python -m hronir_encyclopedia.cli store drafts/01_my_variant.md --prev <previous_uuid>
+
+# Then, store it to get a hrönir UUID.
+# You also need to ensure a forking_path entry is created for this hrönir,
+# which will define its `fork_uuid`. The `store` command may be enhanced in the future
+# to streamline `fork_uuid` creation/reporting.
+uv run python -m hronir_encyclopedia.cli store drafts/01_my_variant.md --prev <uuid_of_predecessor_hronir>
 ```
 
 Happy writing—may your version prove itself the inevitable one.

--- a/README.md
+++ b/README.md
@@ -133,30 +133,31 @@ Chapter 0: The Mirror of Enigmas (seed)
 
 ## 🧩 The Mechanics of Narrative Possibility Space
 
-Each new chapter (`n`) is created through:
+Each new chapter (`n`):
 
-1. **Semantic extraction**: Previous chapters (0 to n-1) are analyzed via semantic embeddings to extract themes, concepts, and stylistic markers.
-2. **Prompt synthesis**: A unified prompt is formulated, combining these extracted narrative elements into a coherent instruction for the LLM.
-3. **LLM Generation**: The model generates a chapter that logically and creatively integrates the accumulated narrative history, maintaining a consistent Borgesian tone and theme.
+- Is synthesized by considering the entire narrative space of all previously generated chapters (`0` through `n-1`).
+- Employs a sophisticated language model (LLM), guided by a carefully crafted **synthesis prompt** that encapsulates themes, motifs, characters, and ideas accumulated thus far.
+- Can exist in multiple variants (e.g., `2_a`, `2_b`, `2_c`), each exploring different interpretations of the collective narrative space.
 
-This process ensures each new chapter reflects not only isolated events but also echoes, reflections, and metaphorical nuances that have organically developed throughout the entire narrative journey.
+The narrative expands exponentially, creating a network of infinite possibilities. Each act of creation (generating a new hrönir and its associated `fork_uuid`) grants the author a mandate to participate in a **Judgment Session**, potentially influencing the canonical interpretation of all preceding history.
 
 ---
 
-## ⚔️ Selecting the True Chapter
+## ⚔️ Selecting the True Narrative Path (Canonical Forks)
 
-- Variants within the same chapter position compete through **paired reader evaluations** (literary duels).
-- Results of these duels are recorded using an **Elo-based literary ranking system**, establishing a probabilistic hierarchy among competing versions.
-- Over time, a dominant version emerges for each chapter position—the "canonical Hrönir"—acknowledged by readers as the authentic narrative branch through their collective experience.
-- Winning chapters are copied into the `book/` folder, and each selection constrains the possibilities for subsequent chapters via updated forking paths.
+- Forks (transitions between hrönirs) at the same position and lineage compete through **Judgment Sessions**.
+- Veredicts from these sessions are recorded as votes, updating Elo ratings for the involved forks.
+- An Elo-based ranking system establishes a probabilistic hierarchy among competing forks.
+- The **Temporal Cascade**, triggered by `session commit`, recalculates the `data/canonical_path.json`. This path represents the sequence of forks deemed most "inevitable" by collective judgment.
+- The "canonical hrönirs" are those that lie along this canonical path of forks.
 
-Example Elo ranking for Chapter 2 variants:
+Example Elo ranking for forks at Position 2 (assuming a specific predecessor from Position 1):
 
-| Chapter 2 | Elo  | Wins | Losses |
-|-----------|------|------|--------|
-| `2_c`     | 1580 | 14   | 4      |
-| `2_a`     | 1512 | 10   | 8      |
-| `2_b`     | 1465 | 7    | 11     |
+| Fork UUID (leading to Hrönir) | Elo  | Wins | Losses |
+|-------------------------------|------|------|--------|
+| `fork_uuid_2c_xyz...`         | 1580 | 14   | 4      |
+| `fork_uuid_2a_abc...`         | 1512 | 10   | 8      |
+| `fork_uuid_2b_pqr...`         | 1465 | 7    | 11     |
 
 ---
 
@@ -242,6 +243,8 @@ uv run python -m hronir_encyclopedia.cli store drafts/my_chapter.md --prev <uuid
 uv run python -m hronir_encyclopedia.cli ranking --position 1
 
 # Validate a human-contributed chapter (basic check)
+# Note: Validation is primarily for the textual content. The hrönir's place in the
+# narrative structure is defined by its forking path entry.
 uv run python -m hronir_encyclopedia.cli validate --chapter drafts/my_chapter.md
 
 # Audit and repair stored hrönirs, forking paths, and votes
@@ -249,49 +252,29 @@ uv run python -m hronir_encyclopedia.cli audit
 
 # Remove invalid hrönirs, forking paths, or votes
 uv run python -m hronir_encyclopedia.cli clean --git
-```
-
-### Legacy/Informational Commands
-The following commands relate to older mechanisms or provide specific information:
-
-```bash
-# Synthesize (generate chapters and cast an initial vote - may be outdated by session model)
-# uv run python -m hronir_encyclopedia.cli synthesize \
-#  --position 1 \
-#  --prev <uuid_do_hronir_predecessor_canonico_da_posicao_0>
 
 # Get the current "Duel of Maximum Entropy" for a position (used internally by `session start`)
+# This can be useful to understand what duel a new session might present for a given position.
 uv run python -m hronir_encyclopedia.cli get-duel --position 1
 
-# Submit a direct vote for a specific duel (legacy, prefer session commit)
-# This was part of the older PoW and Entropic Dueling system.
-# The `voter-fork-uuid` here is the PoW from creating a new fork.
-# uv run python -m hronir_encyclopedia.cli vote \
-#  --position 1 \
-#  --voter-fork-uuid <seu_fork_uuid_de_prova_de_trabalho> \
-#  --winner-fork-uuid <fork_uuid_A_do_get_duel> \
-#  --loser-fork-uuid <fork_uuid_B_do_get_duel>
-
-# Consolidate book (manual trigger for canonical path recalculation)
-# Note: Under the "Tribunal of the Future" protocol, the primary way the canonical
-# path is updated is via the Temporal Cascade triggered by `session commit`.
-# This command might be used for recovery, debugging, or initial setup.
+# Consolidate book (trigger Temporal Cascade from position 0)
+# Under the "Tribunal of the Future" protocol, the canonical path is primarily updated
+# by the Temporal Cascade triggered by `session commit` (starting from the oldest voted position).
+# The `consolidate-book` command now serves as a manual way to trigger this cascade
+# from the very beginning (position 0), useful for initialization, full recalculations, or recovery.
 uv run python -m hronir_encyclopedia.cli consolidate-book
 ```
 
-The `store` command is crucial for generating new `hrönir` and, through associated forking path entries, the `fork_uuid` necessary to initiate a Judgment Session. The direct `vote` command is now largely superseded by the `session commit` mechanism, which provides a more comprehensive way to influence the narrative.
+The `store` command is crucial for generating new `hrönir` and, through associated forking path entries, the `fork_uuid` necessary to initiate a Judgment Session. Direct voting via a `vote` command is deprecated; all judgments are now channeled through the `session commit` mechanism.
 
 ## 🔏 Proof-of-Work (Mandate for Judgment)
 
-Previously, Proof-of-Work (creating a new `fork_uuid` by storing a hrönir and linking it in a forking path) granted the right to cast a single vote in a specific, system-curated duel via `get-duel` and `vote`.
+Creating a new `fork_uuid` (by storing a hrönir at Position `N` and ensuring its corresponding entry in a forking path CSV) serves as your Proof-of-Work.
 
-Under the "Tribunal of the Future" (Protocol v2):
-*   Creating a new `fork_uuid` (at Position `N`) still serves as your Proof-of-Work.
-*   However, this `fork_uuid` now acts as a **mandate** to initiate a `session start --position N --fork-uuid <your_fork_N_uuid>`.
-*   This session gives you the right to cast veredicts on *any subset* of duels from prior positions (`N-1` down to `0`) as presented in the session's static dossier.
-*   The `get-duel` command still shows the current maximum entropy duel for a position, which is what `session start` uses internally to build the dossier. The old direct `vote` command is less central to the new workflow.
+This `fork_uuid` acts as a **mandate** to initiate a `session start --position N --fork-uuid <your_fork_N_uuid>`.
+This session grants you the right to cast veredicts on *any subset* of duels from prior positions (`N-1` down to `0`), as presented in the session's static dossier. Each duel in the dossier is the one of maximum entropy for its position at the time the session was started.
 
-This new system elevates the impact of each contribution, allowing a single act of creation to potentially influence the entire preceding narrative history through a structured judgment process.
+This system elevates the impact of each contribution, allowing a single act of creation to potentially influence the entire preceding narrative history through a structured and auditable judgment process. The `get-duel` command can still be used to see what the current maximum entropy duel for a specific position is, which is what `session start` uses internally to build the dossier.
 
 ## Development Setup
 


### PR DESCRIPTION


- Refactored `consolidate-book` CLI command to use `run_temporal_cascade`.
- Removed the legacy `vote` CLI command.
- Updated README.md and CONTRIBUTING.md to reflect the new session-based workflow.
- Implemented Test Scenario 2 (Full Temporal Cascade) to verify history rewrite.
- Implemented Test Scenario 3 (Dormant Vote Reactivation) to ensure past votes influence future canonical path calculations when their lineage becomes relevant.