### PR TITLE
Add status command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,12 @@ uv run hronir ranking <position>
 # Get duel information
 uv run hronir get-duel --position <position>
 
+# Generate fork status metrics
+uv run hronir metrics
+
+# Show canonical path summary
+uv run hronir status
+
 # Trigger manual canonical path recovery
 uv run hronir recover-canon
 ```

--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ uv run hronir get-duel --position 1
 # Generate fork status metrics in Prometheus format
 uv run hronir metrics
 
+# Show canonical path summary and fork status counts
+uv run hronir status
+
 # Recover canon / Consolidate book (trigger Temporal Cascade from position 0)
 # Under the "Tribunal of the Future" protocol, the canonical path is primarily updated
 # by the Temporal Cascade triggered by `session commit`.


### PR DESCRIPTION
## Summary
- implement `status` command to summarize canonical path
- reuse metrics calculation and expose helper
- document new command in README and CLAUDE guidance

## Testing
- `uv run ruff check .` *(fails: 11 errors)*
- `uv run black hronir_encyclopedia/cli.py`
- `uv run pytest` *(fails: 25 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685a3ad8f3448325b28216c8f9b1c129