### PR TITLE
Add canonical path status CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,10 @@ uv run hronir list-forks --position <position>
 # Check status of a specific fork
 uv run hronir fork-status <fork_uuid>
 
+# Show canonical path status
+uv run hronir status
+uv run hronir status --counts
+
 # Get duel information
 uv run hronir get-duel --position <position>
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ uv run hronir list-forks --position 1
 # Check status of a specific fork
 uv run hronir fork-status <fork_uuid>
 
+# Show the current canonical path
+uv run hronir status
+# Include counts of forks by status
+uv run hronir status --counts
+
 # Validate a human-contributed chapter (basic check)
 uv run hronir validate drafts/my_chapter.md
 


### PR DESCRIPTION
## Summary
- add `status` command to display the canonical path
- show optional fork status counts
- document the command in README and CLAUDE

## Testing
- `uv run ruff check .` *(fails: F401 and other errors)*
- `uv run black .`
- `uv run pytest -q` *(fails: IntegrityError and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a4ff038e08325a73eb64cf5ae0068