### PR TITLE
Refactor purge_fake_votes_csv signature

### DIFF
--- a/hronir_encyclopedia/storage.py
+++ b/hronir_encyclopedia/storage.py
@@ -6,7 +6,6 @@ import uuid
 from pathlib import Path
 
 import pandas as pd
-from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session as SQLAlchemySession  # Renamed to avoid conflict
 
 from .models import (
@@ -894,8 +893,6 @@ def purge_fake_forking_csv(csv_path: Path, base: Path | str = "the_library") -> 
 def purge_fake_votes_csv(
     csv_path: Path,
     base: Path | str = "the_library",
-    fork_dir: Path | str = "forking_path",
-    conn: Engine | None = None,
 ) -> int:
     """Remove votes referencing missing chapters or duplicate voters."""
     import pandas as pd
@@ -922,7 +919,7 @@ def purge_fake_votes_csv(
         if voter in seen:
             removed += 1
             continue
-        if not forking_path_exists(voter, fork_dir, conn=conn):
+        if not forking_path_exists(voter):
             removed += 1
             continue
         if not (is_valid_uuid_v5(winner) and chapter_exists(winner, base)):

--- a/hronir_encyclopedia/transaction_manager.py
+++ b/hronir_encyclopedia/transaction_manager.py
@@ -108,7 +108,7 @@ def _get_all_forks_at_position(
         if predecessor_uuid is None:  # Position 0 case
             if position_num == 0:
                 query = query.filter(
-                    (storage.ForkDB.prev_uuid is None) | (storage.ForkDB.prev_uuid == "")  # noqa E711
+                    storage.ForkDB.prev_uuid.is_(None) | (storage.ForkDB.prev_uuid == "")  # noqa: E711
                 )
             else:
                 # For positions > 0, a predecessor_uuid should generally be specified.

--- a/tests/test_sessions_and_cascade.py
+++ b/tests/test_sessions_and_cascade.py
@@ -127,8 +127,10 @@ def _create_fork_entry(
     )
 
     storage.append_fork(
-        csv_file, position, prev_hr_uuid, current_hr_uuid, conn=None
-    )  # conn=None for CSV
+        position=position,
+        prev_uuid=prev_hr_uuid,
+        uuid_str=current_hr_uuid,
+    )
 
 
 def _get_fork_uuid(position: int, prev_hr_uuid: str, current_hr_uuid: str) -> str:

--- a/tests/test_storage_and_votes.py
+++ b/tests/test_storage_and_votes.py
@@ -124,7 +124,7 @@ def test_clean_functions(tmp_path):
         },
     ]
     pd.DataFrame(rows).to_csv(rating_csv, index=False)
-    removed = storage.purge_fake_votes_csv(rating_csv, base=base, fork_dir=fork_dir)
+    removed = storage.purge_fake_votes_csv(rating_csv, base=base)
     assert removed == 2
     df = pd.read_csv(rating_csv)
     assert len(df) == 1


### PR DESCRIPTION
## Summary
- remove unused `fork_dir` and `conn` parameters from `purge_fake_votes_csv`
- update filter logic for position zero queries
- adjust unit tests for new `append_fork` call signature

## Testing
- `uv run ruff check hronir_encyclopedia/storage.py hronir_encyclopedia/transaction_manager.py tests/test_sessions_and_cascade.py tests/test_storage_and_votes.py`
- `uv run pytest tests/test_storage_and_votes.py::test_clean_functions -q` *(fails: UNIQUE constraint failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a85de130883258a901ed407438865