### PR TITLE
Refactor: Perform house cleaning tasks from TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -49,18 +49,18 @@ This document outlines the development roadmap for the **Hrönir Encyclopedia** 
 - [ ] **System Status Command**: `hronir status` to show current canonical path and system state
 
 ### Phase 6 — Architectural Cleanup 🔧
-- [ ] **Remove Creator Attribution**: Eliminate `creator_id` from forking path structure (pure meritocracy)
+- [x] **Remove Creator Attribution**: Eliminate `creator_id` from forking path structure (pure meritocracy) ✅ COMPLETED
 - [ ] **Fix CLI Parameter Mismatches**: `get_ranking()` function signature vs CLI usage
 - [ ] **Empty CSV Handling**: Graceful handling of empty CSV files in database loading
 - [ ] **Storage Parameter Cleanup**: Remove outdated `--prev` parameter from store command ✅ COMPLETED
-- [ ] **Anonymous Forking**: Ensure all fork creation is content-based, not author-based
+- [x] **Anonymous Forking**: Ensure all fork creation is content-based, not author-based ✅ COMPLETED
 
 ### Phase 7 — Documentation & UX 🎯
-- [ ] **Fix Documentation Confusion**: Remove all `--prev` parameter references from documentation
+- [x] **Fix Documentation Confusion**: Remove all `--prev` parameter references from documentation ✅ COMPLETED
 - [ ] **Update Fork Examples**: Replace confusing hrönir/fork terminology with clear source → target examples
 - [ ] **Node/Edge Distinction**: Clarify hrönirs (nodes) vs forking_paths (edges) in docs
 - [ ] **Complete Workflow Guide**: "Store → Fork → Vote" tutorial with clean CLI examples
-- [ ] **Remove Creator Attribution**: Eliminate all references to creator/author tracking (pure meritocracy)
+- [x] **Remove Creator Attribution**: Eliminate all references to creator/author tracking (pure meritocracy) ✅ COMPLETED
 - [ ] **CLI Reference**: Complete command reference with new `--source` `--target` parameters
 - [ ] **Architecture Overview**: Visual diagram of hybrid storage system
 

--- a/forking_path/test_forks.csv
+++ b/forking_path/test_forks.csv
@@ -1,7 +1,7 @@
-position,prev_uuid,uuid,fork_uuid,creator_id,status,undiscovered
-0,,534a2a54-695f-5609-b3be-9be0d3b368a1,c83476d6-8446-5442-b087-02783bbfd3e3,test_user,PENDING,True
-1,534a2a54-695f-5609-b3be-9be0d3b368a1,c365ee75-5bd5-5a58-8cb7-27eb80d6b4f2,9562db9b-4094-5148-b049-defa275b59d2,test_user,PENDING,False
-1,534a2a54-695f-5609-b3be-9be0d3b368a1,30258b21-dcea-51c2-9fd5-9ef4537270a6,c69fe786-73a3-53a6-b04a-7d6840509b82,test_user,PENDING,False
-2,c365ee75-5bd5-5a58-8cb7-27eb80d6b4f2,17cd1d18-9737-5aab-9598-01a6e963083d,de8828d6-7e17-5a4e-9481-5d62ff5fd657,test_user,PENDING,False
-2,c365ee75-5bd5-5a58-8cb7-27eb80d6b4f2,1ec9e482-51a9-5bc0-b2d2-294229d9c875,f8d9c90b-e2f1-5f6d-bf66-de238f8e9bb1,test_user,PENDING,False
-2,c365ee75-5bd5-5a58-8cb7-27eb80d6b4f2,a9d7b118-326f-5ce7-816f-d24464e798ab,9dbd9308-8c83-5673-9c79-c2c15cba51cc,test_user,PENDING,False
+position,prev_uuid,uuid,fork_uuid,status,undiscovered
+0,,534a2a54-695f-5609-b3be-9be0d3b368a1,c83476d6-8446-5442-b087-02783bbfd3e3,PENDING,True
+1,534a2a54-695f-5609-b3be-9be0d3b368a1,c365ee75-5bd5-5a58-8cb7-27eb80d6b4f2,9562db9b-4094-5148-b049-defa275b59d2,PENDING,False
+1,534a2a54-695f-5609-b3be-9be0d3b368a1,30258b21-dcea-51c2-9fd5-9ef4537270a6,c69fe786-73a3-53a6-b04a-7d6840509b82,PENDING,False
+2,c365ee75-5bd5-5a58-8cb7-27eb80d6b4f2,17cd1d18-9737-5aab-9598-01a6e963083d,de8828d6-7e17-5a4e-9481-5d62ff5fd657,PENDING,False
+2,c365ee75-5bd5-5a58-8cb7-27eb80d6b4f2,1ec9e482-51a9-5bc0-b2d2-294229d9c875,f8d9c90b-e2f1-5f6d-bf66-de238f8e9bb1,PENDING,False
+2,c365ee75-5bd5-5a58-8cb7-27eb80d6b4f2,a9d7b118-326f-5ce7-816f-d24464e798ab,9dbd9308-8c83-5673-9c79-c2c15cba51cc,PENDING,False

--- a/hronir_encyclopedia/cli.py
+++ b/hronir_encyclopedia/cli.py
@@ -73,15 +73,15 @@ def init_test(
     library_dir: Annotated[
         Path, typer.Option(help="Directory to store sample hr\u00f6nirs.")
     ] = Path("the_library"),
-    forking_path_dir: Annotated[
-        Path, typer.Option(help="Directory for fork CSV files.")
-    ] = Path("forking_path"),
-    ratings_dir: Annotated[
-        Path, typer.Option(help="Directory for rating CSV files.")
-    ] = Path("ratings"),
-    data_dir: Annotated[
-        Path, typer.Option(help="Directory for canonical data files.")
-    ] = Path("data"),
+    forking_path_dir: Annotated[Path, typer.Option(help="Directory for fork CSV files.")] = Path(
+        "forking_path"
+    ),
+    ratings_dir: Annotated[Path, typer.Option(help="Directory for rating CSV files.")] = Path(
+        "ratings"
+    ),
+    data_dir: Annotated[Path, typer.Option(help="Directory for canonical data files.")] = Path(
+        "data"
+    ),
 ) -> None:
     """Create sample directories, chapters, forks, and a canonical path."""
     library_dir.mkdir(parents=True, exist_ok=True)
@@ -136,9 +136,7 @@ def validate(
     """
     # The original logic was just a print, keeping it simple.
     # More complex validation would go into storage.validate_or_move
-    typer.echo(
-        f"Chapter file {chapter} exists and is readable. Basic validation passed."
-    )
+    typer.echo(f"Chapter file {chapter} exists and is readable. Basic validation passed.")
     # For a more meaningful validation, one might call storage.validate_or_move or parts of it.
 
 
@@ -165,9 +163,7 @@ def store(
 @app.command(help="Create a narrative connection (fork) between hrönirs.")
 def fork(
     position: Annotated[int, typer.Option(help="Position in the narrative sequence")],
-    target: Annotated[
-        str, typer.Option(help="Target hrönir UUID (destination content node)")
-    ],
+    target: Annotated[str, typer.Option(help="Target hrönir UUID (destination content node)")],
     source: Annotated[
         str, typer.Option(help="Source hrönir UUID (empty string for position 0)")
     ] = "",
@@ -381,9 +377,7 @@ def status(
     ] = False,
     forking_path_dir: Annotated[
         Path,
-        typer.Option(
-            help="Directory containing forking path CSV files (for --counts)."
-        ),
+        typer.Option(help="Directory containing forking path CSV files (for --counts)."),
     ] = Path("forking_path"),
 ) -> None:
     """Show canonical path entries and optional fork status counts."""
@@ -452,29 +446,19 @@ def audit():
             typer.echo("WARNING: Narrative graph contains cycles!")
     else:
         typer.echo(f"Forking path directory {fork_dir} not found. Skipping audit.")
-    typer.echo(
-        "Audit complete (Note: hrönir validation primarily via 'clean' command)."
-    )
+    typer.echo("Audit complete (Note: hrönir validation primarily via 'clean' command).")
 
 
-@app.command(
-    help="Generate competing chapters from a predecessor and record an initial vote."
-)
+@app.command(help="Generate competing chapters from a predecessor and record an initial vote.")
 def synthesize(
-    position: Annotated[
-        int, typer.Option(help="Chapter position for the new hrönirs.")
-    ],
-    prev: Annotated[
-        str, typer.Option(help="UUID of the predecessor chapter to fork from.")
-    ],
+    position: Annotated[int, typer.Option(help="Chapter position for the new hrönirs.")],
+    prev: Annotated[str, typer.Option(help="UUID of the predecessor chapter to fork from.")],
 ):
     """
     Synthesizes two new hrönirs from a predecessor for a given position
     and records an initial 'vote' or assessment by the generating agent.
     """
-    typer.echo(
-        f"Synthesizing two new hrönirs from predecessor '{prev}' at position {position}..."
-    )
+    typer.echo(f"Synthesizing two new hrönirs from predecessor '{prev}' at position {position}...")
     with database.open_database() as conn:
         voter_uuid = "00000000-agent-0000-0000-000000000000"  # Example agent UUID
         winner_uuid = gemini_util.auto_vote(position, prev, voter_uuid, conn=conn)
@@ -541,10 +525,7 @@ def get_duel(
         canonical_fork_info_prev_pos = storage.get_canonical_fork_info(
             position - 1, canonical_path_file
         )
-        if (
-            not canonical_fork_info_prev_pos
-            or "hrönir_uuid" not in canonical_fork_info_prev_pos
-        ):
+        if not canonical_fork_info_prev_pos or "hrönir_uuid" not in canonical_fork_info_prev_pos:
             typer.echo(
                 json.dumps(
                     {
@@ -633,9 +614,7 @@ def _git_remove_deleted_files():  # Renamed to avoid conflict and be more descri
         typer.echo("Git command not found. Skipping Git operations.", err=True)
     except subprocess.CalledProcessError as e:
         if "not a git repository" in e.stderr.lower():
-            typer.echo(
-                "Not inside a Git repository. Skipping Git operations for deleted files."
-            )
+            typer.echo("Not inside a Git repository. Skipping Git operations for deleted files.")
         else:
             typer.echo(f"Git ls-files or rm command failed: {e.stderr}", err=True)
     except Exception as e:
@@ -646,9 +625,7 @@ def _git_remove_deleted_files():  # Renamed to avoid conflict and be more descri
 def clean(
     git_stage_deleted: Annotated[
         bool,
-        typer.Option(
-            "--git", help="Also stage deleted files for removal in the Git index."
-        ),
+        typer.Option("--git", help="Also stage deleted files for removal in the Git index."),
     ] = False,
 ):
     """
@@ -662,9 +639,7 @@ def clean(
     if fork_dir.exists():
         typer.echo(f"Cleaning fake forking CSVs in {fork_dir}...")
         for csv_file in fork_dir.glob("*.csv"):
-            storage.purge_fake_forking_csv(
-                csv_file
-            )  # Assumes this function prints its actions
+            storage.purge_fake_forking_csv(csv_file)  # Assumes this function prints its actions
     else:
         typer.echo(f"Forking path directory {fork_dir} not found. Skipping.")
 
@@ -672,9 +647,7 @@ def clean(
     if rating_dir.exists():
         typer.echo(f"Cleaning fake votes CSVs in {rating_dir}...")
         for csv_file in rating_dir.glob("*.csv"):
-            storage.purge_fake_votes_csv(
-                csv_file
-            )  # Assumes this function prints its actions
+            storage.purge_fake_votes_csv(csv_file)  # Assumes this function prints its actions
     else:
         typer.echo(f"Ratings directory {rating_dir} not found. Skipping.")
 
@@ -717,9 +690,7 @@ session_app = typer.Typer(help="Manage Hrönir judgment sessions.", no_args_is_h
 app.add_typer(session_app, name="session")
 
 
-@session_app.command(
-    "start", help="Initiate a Judgment Session using a QUALIFIED fork's mandate."
-)
+@session_app.command("start", help="Initiate a Judgment Session using a QUALIFIED fork's mandate.")
 def session_start(
     # position: Annotated[int, typer.Option("--position", "-p", help="The current position N of the new fork being created.")], # Position is now derived from fork_uuid
     fork_uuid: Annotated[
@@ -799,9 +770,7 @@ def session_start(
     except ValueError:
         typer.echo(
             json.dumps(
-                {
-                    "error": f"Fork UUID {fork_uuid} has an invalid position: {position_n_str}."
-                },
+                {"error": f"Fork UUID {fork_uuid} has an invalid position: {position_n_str}."},
                 indent=2,
             )
         )
@@ -810,9 +779,7 @@ def session_start(
     if position < 0:  # Should be caught by storage validation, but good to check.
         typer.echo(
             json.dumps(
-                {
-                    "error": f"Fork UUID {fork_uuid} has an invalid negative position: {position}."
-                },
+                {"error": f"Fork UUID {fork_uuid} has an invalid negative position: {position}."},
                 indent=2,
             )
         )
@@ -967,9 +934,7 @@ def session_start(
         )
     except Exception as e:
         # Catch any other errors during session creation (e.g., file system issues)
-        typer.echo(
-            json.dumps({"error": f"Failed to create session: {str(e)}"}, indent=2)
-        )
+        typer.echo(json.dumps({"error": f"Failed to create session: {str(e)}"}, indent=2))
         raise typer.Exit(code=1)
 
 
@@ -1018,9 +983,7 @@ def run_temporal_cascade(
             "path": {},
         }
 
-    if "path" not in canonical_path_data or not isinstance(
-        canonical_path_data["path"], dict
-    ):
+    if "path" not in canonical_path_data or not isinstance(canonical_path_data["path"], dict):
         canonical_path_data["path"] = {}
 
     updated_any_position_in_cascade = False
@@ -1043,13 +1006,8 @@ def run_temporal_cascade(
             predecessor_hronir_uuid_for_ranking = None
         else:
             # Get the hrönir_uuid from the *just determined* canonical fork of the previous position
-            prev_pos_canonical_info = canonical_path_data["path"].get(
-                str(current_pos_idx - 1)
-            )
-            if (
-                not prev_pos_canonical_info
-                or "hrönir_uuid" not in prev_pos_canonical_info
-            ):
+            prev_pos_canonical_info = canonical_path_data["path"].get(str(current_pos_idx - 1))
+            if not prev_pos_canonical_info or "hrönir_uuid" not in prev_pos_canonical_info:
                 typer_echo(
                     f"Cascade broken: Canonical fork for position {current_pos_idx - 1} not found during cascade. Stopping."
                 )
@@ -1124,13 +1082,9 @@ def run_temporal_cascade(
         try:
             canonical_path_file.parent.mkdir(parents=True, exist_ok=True)
             canonical_path_file.write_text(json.dumps(canonical_path_data, indent=2))
-            typer_echo(
-                f"Temporal Cascade: Canonical path file updated: {canonical_path_file}"
-            )
+            typer_echo(f"Temporal Cascade: Canonical path file updated: {canonical_path_file}")
         except Exception as e:
-            typer_echo(
-                f"Temporal Cascade: Error writing canonical path file: {e}", err=True
-            )
+            typer_echo(f"Temporal Cascade: Error writing canonical path file: {e}", err=True)
             # Depending on policy, this might need to raise an exception or handle failure
     else:
         typer_echo(
@@ -1164,24 +1118,16 @@ def session_commit(
     ],
     ratings_dir: Annotated[
         Path, typer.Option(help="Directory containing rating CSV files.")
-    ] = Path(
-        "ratings"
-    ),  # Retained for run_temporal_cascade
+    ] = Path("ratings"),  # Retained for run_temporal_cascade
     forking_path_dir: Annotated[
         Path, typer.Option(help="Directory containing forking path CSV files.")
-    ] = Path(
-        "forking_path"
-    ),  # Retained for _get_successor_hronir_for_fork and cascade
+    ] = Path("forking_path"),  # Retained for _get_successor_hronir_for_fork and cascade
     canonical_path_file: Annotated[
         Path, typer.Option(help="Path to the canonical path JSON file.")
-    ] = Path(
-        "data/canonical_path.json"
-    ),  # Retained for run_temporal_cascade
+    ] = Path("data/canonical_path.json"),  # Retained for run_temporal_cascade
     max_cascade_positions: Annotated[
         int,
-        typer.Option(
-            help="Maximum number of positions for temporal cascade calculation."
-        ),
+        typer.Option(help="Maximum number of positions for temporal cascade calculation."),
     ] = 100,
 ):
     """
@@ -1216,9 +1162,7 @@ def session_commit(
     """
     session_data = session_manager.get_session(session_id)
     if not session_data:
-        typer.echo(
-            json.dumps({"error": f"Session ID {session_id} not found."}, indent=2)
-        )
+        typer.echo(json.dumps({"error": f"Session ID {session_id} not found."}, indent=2))
         raise typer.Exit(code=1)
 
     if session_data.get("status") != "active":
@@ -1241,9 +1185,7 @@ def session_commit(
         except Exception as e:
             typer.echo(
                 json.dumps(
-                    {
-                        "error": f"Failed to parse verdicts JSON file {verdicts_input}: {e}"
-                    },
+                    {"error": f"Failed to parse verdicts JSON file {verdicts_input}: {e}"},
                     indent=2,
                 )
             )
@@ -1253,36 +1195,28 @@ def session_commit(
             verdicts = json.loads(verdicts_input)
         except Exception as e:
             typer.echo(
-                json.dumps(
-                    {"error": f"Failed to parse verdicts JSON string: {e}"}, indent=2
-                )
+                json.dumps({"error": f"Failed to parse verdicts JSON string: {e}"}, indent=2)
             )
             raise typer.Exit(code=1)
 
     if not isinstance(verdicts, dict):
-        typer.echo(
-            json.dumps(
-                {"error": "Verdicts must be a JSON object (dictionary)."}, indent=2
-            )
-        )
+        typer.echo(json.dumps({"error": "Verdicts must be a JSON object (dictionary)."}, indent=2))
         raise typer.Exit(code=1)
 
     initiating_fork_uuid = session_data["initiating_fork_uuid"]
     dossier_duels = session_data.get("dossier", {}).get("duels", {})
 
     valid_votes_to_record = []
-    processed_verdicts: dict[str, str] = (
-        {}
-    )  # For transaction record: position_str -> winning_fork_uuid
+    processed_verdicts: dict[
+        str, str
+    ] = {}  # For transaction record: position_str -> winning_fork_uuid
     oldest_voted_position = float("inf")
 
     for pos_str, winning_fork_uuid_verdict in verdicts.items():
         if not isinstance(winning_fork_uuid_verdict, str):
             typer.echo(
                 json.dumps(
-                    {
-                        "warning": f"Verdict for position {pos_str} is not a string. Skipping."
-                    },
+                    {"warning": f"Verdict for position {pos_str} is not a string. Skipping."},
                     indent=2,
                 )
             )
@@ -1294,9 +1228,7 @@ def session_commit(
             if position_idx < 0:  # Ensure positive position
                 typer.echo(
                     json.dumps(
-                        {
-                            "warning": f"Invalid position {pos_str} in verdicts. Skipping."
-                        },
+                        {"warning": f"Invalid position {pos_str} in verdicts. Skipping."},
                         indent=2,
                     )
                 )
@@ -1304,9 +1236,7 @@ def session_commit(
         except ValueError:
             typer.echo(
                 json.dumps(
-                    {
-                        "warning": f"Invalid position key '{pos_str}' in verdicts. Skipping."
-                    },
+                    {"warning": f"Invalid position key '{pos_str}' in verdicts. Skipping."},
                     indent=2,
                 )
             )
@@ -1338,9 +1268,7 @@ def session_commit(
             )
             continue
 
-        loser_fork_uuid_verdict = (
-            fork_a if winning_fork_uuid_verdict == fork_b else fork_b
-        )
+        loser_fork_uuid_verdict = fork_a if winning_fork_uuid_verdict == fork_b else fork_b
 
         # Map fork UUIDs to their successor hrönir UUIDs for voting
         # _get_successor_hronir_for_fork is defined in cli.py
@@ -1428,9 +1356,7 @@ def session_commit(
                 {
                     "message": "Transaction processing complete.",
                     "transaction_uuid": transaction_result["transaction_uuid"],
-                    "promotions_granted": transaction_result.get(
-                        "promotions_granted", []
-                    ),
+                    "promotions_granted": transaction_result.get("promotions_granted", []),
                 },
                 indent=2,
             )
@@ -1463,9 +1389,7 @@ def session_commit(
         if update_spent_success:
             typer.echo(
                 json.dumps(
-                    {
-                        "message": f"Fork {initiating_fork_uuid} status updated to SPENT."
-                    },
+                    {"message": f"Fork {initiating_fork_uuid} status updated to SPENT."},
                     indent=2,
                 )
             )
@@ -1491,9 +1415,7 @@ def session_commit(
 
     # Trigger Temporal Cascade (SC.11)
     # Use oldest_voted_position from transaction_result
-    tm_oldest_voted_position = transaction_result.get(
-        "oldest_voted_position", float("inf")
-    )
+    tm_oldest_voted_position = transaction_result.get("oldest_voted_position", float("inf"))
 
     if tm_oldest_voted_position != float("inf") and tm_oldest_voted_position >= 0:
         typer.echo(
@@ -1510,9 +1432,7 @@ def session_commit(
             if cascade_made_changes:
                 typer.echo(
                     json.dumps(
-                        {
-                            "message": "Temporal Cascade completed and updated the canonical path."
-                        },
+                        {"message": "Temporal Cascade completed and updated the canonical path."},
                         indent=2,
                     )
                 )
@@ -1527,9 +1447,7 @@ def session_commit(
                 )
 
         except Exception as e:
-            typer.echo(
-                json.dumps({"error": f"Temporal Cascade failed: {e}."}, indent=2)
-            )
+            typer.echo(json.dumps({"error": f"Temporal Cascade failed: {e}."}, indent=2))
             # Votes and TX recorded, but cascade failed. State is inconsistent.
             # This needs careful consideration for recovery.
             # For now, we'll report and exit. Session status might indicate this.
@@ -1539,25 +1457,17 @@ def session_commit(
         # This case should be caught by "No valid verdicts" earlier, but as a safeguard:
         typer.echo(
             json.dumps(
-                {
-                    "message": "No votes were cast, so no Temporal Cascade was triggered."
-                },
+                {"message": "No votes were cast, so no Temporal Cascade was triggered."},
                 indent=2,
             )
         )
 
     # Update session status to 'committed'
     session_manager.update_session_status(session_id, "committed")
-    typer.echo(
-        json.dumps(
-            {"message": f"Session {session_id} committed successfully."}, indent=2
-        )
-    )
+    typer.echo(json.dumps({"message": f"Session {session_id} committed successfully."}, indent=2))
 
 
-@app.command(
-    "metrics", help="Expose fork status metrics in Prometheus format (TDD 2.6)."
-)
+@app.command("metrics", help="Expose fork status metrics in Prometheus format (TDD 2.6).")
 def metrics_command(
     forking_path_dir: Annotated[
         Path, typer.Option(help="Directory containing forking path CSV files.")
@@ -1574,9 +1484,7 @@ def metrics_command(
             err=True,
         )
         for status_val, count in status_counts.items():
-            typer.echo(
-                f'hronir_fork_status_total{{status="{status_val.lower()}"}} {count}'
-            )
+            typer.echo(f'hronir_fork_status_total{{status="{status_val.lower()}"}} {count}')
         raise typer.Exit(code=1)
 
     # Print metrics in Prometheus format

--- a/tests/test_graph_logic.py
+++ b/tests/test_graph_logic.py
@@ -3,25 +3,64 @@ from pathlib import Path
 import pandas as pd
 
 from hronir_encyclopedia import graph_logic
+from hronir_encyclopedia import storage # Added for DataManager setup
+
+
+def _setup_data_manager_and_check_consistency(fork_dir_path: Path):
+    """Helper to setup DataManager, load data, and check consistency."""
+    original_fork_csv_dir = storage.data_manager.fork_csv_dir
+    original_ratings_csv_dir = storage.data_manager.ratings_csv_dir # Though not used by graph_logic
+    original_initialized = storage.data_manager._initialized
+    db_cleared_by_this_run = False
+
+    try:
+        storage.data_manager.fork_csv_dir = fork_dir_path
+        # Set ratings_dir to a dummy to avoid issues if it's expected by DataManager init
+        dummy_ratings_dir = fork_dir_path.parent / "dummy_ratings_for_graph_test"
+        dummy_ratings_dir.mkdir(exist_ok=True)
+        storage.data_manager.ratings_csv_dir = dummy_ratings_dir
+
+        storage.data_manager._initialized = False
+        storage.data_manager.clear_in_memory_data()
+        db_cleared_by_this_run = True
+        storage.data_manager.initialize_and_load(clear_existing_data=False)
+
+        # is_narrative_consistent can get its own session if None is passed
+        return graph_logic.is_narrative_consistent(session=None)
+    finally:
+        storage.data_manager.fork_csv_dir = original_fork_csv_dir
+        storage.data_manager.ratings_csv_dir = original_ratings_csv_dir
+        storage.data_manager._initialized = original_initialized
+        if db_cleared_by_this_run and storage.data_manager._initialized:
+             storage.data_manager.clear_in_memory_data()
 
 
 def test_is_narrative_consistent(tmp_path: Path):
     fork_dir = tmp_path / "forking_path"
     fork_dir.mkdir()
-    df = pd.DataFrame(
-        [
-            {"position": 0, "prev_uuid": "", "uuid": "A", "fork_uuid": "fA"},
-            {"position": 1, "prev_uuid": "A", "uuid": "B", "fork_uuid": "fB"},
-            {"position": 2, "prev_uuid": "B", "uuid": "C", "fork_uuid": "fC"},
-        ]
-    )
-    df.to_csv(fork_dir / "path.csv", index=False)
-    assert graph_logic.is_narrative_consistent(fork_dir)
 
-    df_cycle = pd.DataFrame(
+    # Test 1: Consistent graph
+    df_consistent = pd.DataFrame(
         [
-            {"position": 3, "prev_uuid": "C", "uuid": "A", "fork_uuid": "fX"},
+            {"position": 0, "prev_uuid": "", "uuid": "A", "fork_uuid": "fA", "status": "PENDING"},
+            {"position": 1, "prev_uuid": "A", "uuid": "B", "fork_uuid": "fB", "status": "PENDING"},
+            {"position": 2, "prev_uuid": "B", "uuid": "C", "fork_uuid": "fC", "status": "PENDING"},
         ]
     )
-    df_cycle.to_csv(fork_dir / "cycle.csv", index=False)
-    assert not graph_logic.is_narrative_consistent(fork_dir)
+    df_consistent.to_csv(fork_dir / "path_consistent.csv", index=False)
+    assert _setup_data_manager_and_check_consistency(fork_dir)
+
+    # Clean up the CSV for the next part of the test to avoid interference
+    (fork_dir / "path_consistent.csv").unlink()
+
+    # Test 2: Graph with a cycle
+    df_cycle_nodes = pd.DataFrame(
+        [
+            {"position": 0, "prev_uuid": "", "uuid": "A", "fork_uuid": "fA_cycle", "status": "PENDING"},
+            {"position": 1, "prev_uuid": "A", "uuid": "B", "fork_uuid": "fB_cycle", "status": "PENDING"},
+            {"position": 2, "prev_uuid": "B", "uuid": "C", "fork_uuid": "fC_cycle", "status": "PENDING"},
+            {"position": 3, "prev_uuid": "C", "uuid": "A", "fork_uuid": "fX_cycle_back_to_A", "status": "PENDING"}, # Cycle C -> A
+        ]
+    )
+    df_cycle_nodes.to_csv(fork_dir / "path_cycle.csv", index=False)
+    assert not _setup_data_manager_and_check_consistency(fork_dir)

--- a/tests/test_storage_and_votes.py
+++ b/tests/test_storage_and_votes.py
@@ -124,7 +124,34 @@ def test_clean_functions(tmp_path):
         },
     ]
     pd.DataFrame(rows).to_csv(rating_csv, index=False)
-    removed = storage.purge_fake_votes_csv(rating_csv, base=base)
+
+    # Setup DataManager to use the correct fork_dir for this test part
+    original_fork_csv_dir = storage.data_manager.fork_csv_dir
+    original_ratings_csv_dir = storage.data_manager.ratings_csv_dir # Save to restore
+    original_initialized = storage.data_manager._initialized
+    db_cleared_by_this_run = False
+
+    try:
+        storage.data_manager.fork_csv_dir = fork_dir # Point to tmp_path / "forking_path"
+        # Set ratings_dir to a dummy path as it's not directly used by forking_path_exists
+        # but DataManager initialization might expect it.
+        dummy_ratings_dir_for_purge_test = tmp_path / "dummy_ratings_for_purge"
+        dummy_ratings_dir_for_purge_test.mkdir(exist_ok=True)
+        storage.data_manager.ratings_csv_dir = dummy_ratings_dir_for_purge_test
+
+        storage.data_manager._initialized = False
+        storage.data_manager.clear_in_memory_data() # Clear before loading specific test data
+        db_cleared_by_this_run = True
+        storage.data_manager.initialize_and_load(clear_existing_data=False) # Load from fork_dir
+
+        removed = storage.purge_fake_votes_csv(rating_csv, base=base)
+    finally:
+        storage.data_manager.fork_csv_dir = original_fork_csv_dir
+        storage.data_manager.ratings_csv_dir = original_ratings_csv_dir
+        storage.data_manager._initialized = original_initialized
+        if db_cleared_by_this_run and storage.data_manager._initialized:
+            storage.data_manager.clear_in_memory_data()
+
     assert removed == 2
     df = pd.read_csv(rating_csv)
     assert len(df) == 1


### PR DESCRIPTION


- Resolve pre-commit hook conflicts by updating fix_hooks.sh to be more uv-aware and correctly interpret git config outputs.
- Remove `creator_id` from forking path structure, related test code, and documentation, aligning with the pure meritocracy principle.
- Fix documentation confusion by ensuring `--prev` parameter references are removed where appropriate (store/fork commands) and correctly used where still valid (synthesize command).

Note: Some tests in `test_sessions_and_cascade.py` remain failing due to complex Elo/ranking state issues not directly related to these changes.