### PR TITLE
fix(actions): use PAT for auto-format workflow pushes

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }} # Use PAT for checkout
       - uses: astral-sh/setup-uv@v1
         with:
           uv-version: "latest"
@@ -31,7 +32,8 @@ jobs:
             git config user.name "GitHub Actions"
             git config user.email "actions@github.com"
             git commit -am "style: format & lint fix"
-            git push
+            # Use PAT for push
+            git push https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}.git HEAD:${{ github.ref_name }}
           else
             echo "No formatting changes"
           fi


### PR DESCRIPTION
Updates the auto-format GitHub Actions workflow to use a Personal Access Token (PAT) for pushing changes. This resolves the permission denied error that occurred when the workflow attempted to push using the default GITHUB_TOKEN.

The checkout step and the git push command have been modified to utilize the PAT stored in the `GH_PAT` repository secret.