### PR TITLE
fix(actions): use GITHUB_TOKEN permissions for auto-format workflow

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -7,6 +7,8 @@ jobs:
   format:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    permissions: # Add permissions for GITHUB_TOKEN
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Updates the auto-format GitHub Actions workflow to grant `contents: write` permission to the GITHUB_TOKEN.

This allows the workflow to push formatting and linting changes without requiring a Personal Access Token (PAT). The `permissions` key is added at the job level for this purpose.