### PR TITLE
Update HEAD tracking and tests

### DIFF
--- a/hronir_encyclopedia/transaction_manager.py
+++ b/hronir_encyclopedia/transaction_manager.py
@@ -145,7 +145,7 @@ def record_transaction(
         f.write(transaction_model_data.model_dump_json(indent=2))
 
     # Update HEAD to point to this new transaction
-    # HEAD_FILE.write_text(str(transaction_uuid_obj)) # This was missing
+    HEAD_FILE.write_text(str(transaction_uuid_obj))
 
     dm.save_all_data_to_csvs()
 


### PR DESCRIPTION
## Summary
- update transaction_manager to write HEAD
- assert HEAD updates in session and protocol tests

## Testing
- `uv run ruff check hronir_encyclopedia/transaction_manager.py tests/test_sessions_and_cascade.py tests/test_protocol_v2.py`
- `uv run pytest tests/test_sessions_and_cascade.py::TestSessionWorkflow::test_scenario_1_dossier_and_limited_verdict -q` *(fails: Path UUID not found)*
- `uv run pytest tests/test_ranking_filtering.py::test_get_ranking_empty_ratings_files -q` *(fails: assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68613fe0a6388325810add32823983e4