### PR TITLE
Update README resilience section and add DuckDB migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ graph TD
    cp .env.example .env  # and add your GEMINI_API_KEY to .env
    ```
 
-Dependencies are managed with `uv` using `pyproject.toml` and `uv.lock`. Core libraries include [**typer**](https://typer.tiangolo.com/) for the CLI and [**pandas**](https://pandas.pydata.org/) for data manipulation. New packages such as [**Pydantic**](https://docs.pydantic.dev/), [**SQLAlchemy**](https://www.sqlalchemy.org/) and [**NetworkX**](https://networkx.org/) are installed automatically when you run `uv sync`.
+Dependencies are managed with `uv` using `pyproject.toml` and `uv.lock`. Core libraries include [**typer**](https://typer.tiangolo.com/) for the CLI and [**pandas**](https://pandas.pydata.org/) for data manipulation. New packages such as [**Pydantic**](https://docs.pydantic.dev/), [**duckdb**](https://duckdb.org/) and [**NetworkX**](https://networkx.org/) are installed automatically when you run `uv sync`.
 
-The CLI loads rating and narrative path CSVs into a lightweight SQLite database via SQLAlchemy. This temporary database provides transactional updates and easier queries while the canonical CSV files remain on disk.
+The CLI loads rating and narrative path CSVs into a temporary DuckDB database using pandas. This ephemeral database provides transactional updates and easier queries while the canonical CSV files remain on disk.
 
 For an overview of how these libraries work together see [docs/new_libs_plan.md](docs/new_libs_plan.md).
 
 ### Key Libraries
 - **Pydantic** – validates and serializes the protocol's data models.
-- **SQLAlchemy** – powers the SQLite database used for transactional updates.
+- **DuckDB** – lightweight database used for transactional updates.
 - **NetworkX** – enables graph-based analysis of path relationships.
 
 ---
@@ -184,6 +184,24 @@ narrative_paths/
 ratings/
 └── position_*.csv               # Recorded votes for path duels at each position
 ```
+
+---
+
+## 🛡️ Resiliência da Arquitetura Distribuída
+
+Os arquivos CSV versionados em Git continuam sendo a fonte de verdade do protocolo.
+Durante a execução, o CLI carrega esses dados para um banco DuckDB temporário,
+permitindo transações rápidas sem depender de serviços externos. Qualquer clone
+do repositório pode reconstruir o estado completo apenas com esses CSVs.
+
+Para migrar dados antigos para o formato DuckDB, utilize o script:
+
+```bash
+uv run python scripts/migrate_csv_to_duckdb.py --db-path hronir.duckdb
+```
+
+O arquivo `hronir.duckdb` é opcional e pode ser regenerado a qualquer momento a
+partir dos CSVs.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic", # Validação de dados # Operações de grafo
     "networkx",
     "pandas>=2.3.0",
+    "duckdb>=0.10",
     "typer>=0.16.0",
 ]
 

--- a/scripts/migrate_csv_to_duckdb.py
+++ b/scripts/migrate_csv_to_duckdb.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+
+def migrate(db_path: str = "hronir.duckdb") -> None:
+    conn = duckdb.connect(db_path)
+
+    ratings_dir = Path("ratings")
+    for csv_file in ratings_dir.glob("position_*.csv"):
+        if csv_file.stat().st_size == 0:
+            continue
+        pos = int(csv_file.stem.split("_")[1])
+        df = pd.read_csv(csv_file)
+        df["position"] = pos
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS votes (position INTEGER, voter TEXT, winner TEXT, loser TEXT)"
+        )
+        conn.execute("INSERT INTO votes SELECT * FROM df")
+
+    fork_dir = Path("narrative_paths")
+    for csv_file in fork_dir.glob("*.csv"):
+        if csv_file.stat().st_size == 0:
+            continue
+        df = pd.read_csv(csv_file)
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS paths (path_uuid TEXT, position INTEGER, prev_uuid TEXT, uuid TEXT, status TEXT, mandate_id TEXT)"
+        )
+        conn.execute("INSERT INTO paths SELECT * FROM df")
+
+    tx_dir = Path("data/transactions")
+    if tx_dir.exists():
+        for json_file in tx_dir.glob("*.json"):
+            data = json.loads(json_file.read_text())
+            conn.execute("CREATE TABLE IF NOT EXISTS transactions (uuid TEXT, content JSON)")
+            conn.execute(
+                "INSERT INTO transactions VALUES (?, ?)",
+                (data.get("transaction_uuid"), json.dumps(data)),
+            )
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    migrate()


### PR DESCRIPTION
## Summary
- mention DuckDB and update Key Libraries
- document new distributed resilience section with migration script
- provide DuckDB migration helper script
- declare DuckDB dependency

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest -q` *(fails: TypeError in tests/test_protocol_v2.py)*

------
https://chatgpt.com/codex/tasks/task_e_68613fe51b0c83259253f884e48210c4