### PR TITLE
Refactor tests for updated API

### DIFF
--- a/tests/OLD_test_storage_and_votes.py
+++ b/tests/OLD_test_storage_and_votes.py
@@ -88,7 +88,7 @@ def test_clean_functions(tmp_path):
     assert len(df) == 1
 
     fork_uuid_valid = "fork1"
-    fork_dir = tmp_path / "forking_path"
+    fork_dir = tmp_path / "narrative_paths"
     fork_dir.mkdir()
     fork_csv2 = fork_dir / "paths.csv"
     pd.DataFrame(
@@ -132,8 +132,8 @@ def test_clean_functions(tmp_path):
     db_cleared_by_this_run = False
 
     try:
-        storage.data_manager.fork_csv_dir = fork_dir  # Point to tmp_path / "forking_path"
-        # Set ratings_dir to a dummy path as it's not directly used by forking_path_exists
+        storage.data_manager.fork_csv_dir = fork_dir  # Point to tmp_path / "narrative_paths"
+        # Set ratings_dir to a dummy path as it's not directly used by narrative_paths_exists
         # but DataManager initialization might expect it.
         dummy_ratings_dir_for_purge_test = tmp_path / "dummy_ratings_for_purge"
         dummy_ratings_dir_for_purge_test.mkdir(exist_ok=True)

--- a/tests/test_duel_curation.py
+++ b/tests/test_duel_curation.py
@@ -171,7 +171,7 @@ class TestDetermineNextDuelPurelyEntropic:
             ]
         )
 
-        forking_dir = tmp_path / "forking_path"
+        forking_dir = tmp_path / "narrative_paths"
         forking_dir.mkdir()
         ratings_dir = tmp_path / "ratings"  # Adicionado para consistência
         ratings_dir.mkdir()
@@ -213,7 +213,7 @@ class TestDetermineNextDuelPurelyEntropic:
             ]
         )
 
-        forking_dir = tmp_path / "forking_path"
+        forking_dir = tmp_path / "narrative_paths"
         forking_dir.mkdir()
         ratings_dir = tmp_path / "ratings"
         ratings_dir.mkdir()
@@ -232,7 +232,7 @@ class TestDetermineNextDuelPurelyEntropic:
     def test_edge_case_no_hronirs(self, tmp_path, mock_ratings_get_ranking):
         set_df_data = mock_ratings_get_ranking
         set_df_data([])
-        forking_dir = tmp_path / "forking_path"
+        forking_dir = tmp_path / "narrative_paths"
         forking_dir.mkdir()
         ratings_dir = tmp_path / "ratings"
         ratings_dir.mkdir()
@@ -247,7 +247,7 @@ class TestDetermineNextDuelPurelyEntropic:
     def test_edge_case_one_hronir(self, tmp_path, mock_ratings_get_ranking):
         set_df_data = mock_ratings_get_ranking
         set_df_data([{"uuid": str(uuid.uuid4()), "elo": 1500, "total_duels": 0}])
-        forking_dir = tmp_path / "forking_path"
+        forking_dir = tmp_path / "narrative_paths"
         forking_dir.mkdir()
         ratings_dir = tmp_path / "ratings"
         ratings_dir.mkdir()
@@ -270,7 +270,7 @@ class TestDetermineNextDuelPurelyEntropic:
                 {"uuid": h2_new, "elo": 1500, "total_duels": 0},
             ]
         )
-        forking_dir = tmp_path / "forking_path"
+        forking_dir = tmp_path / "narrative_paths"
         forking_dir.mkdir()
         ratings_dir = tmp_path / "ratings"
         ratings_dir.mkdir()
@@ -310,7 +310,7 @@ class TestDetermineNextDuelPurelyEntropic:
         )
         set_df_data(malformed_df_for_test.copy())
 
-        forking_dir = tmp_path / "forking_path"
+        forking_dir = tmp_path / "narrative_paths"
         forking_dir.mkdir()
         ratings_dir = tmp_path / "ratings"
         ratings_dir.mkdir()
@@ -340,7 +340,7 @@ class TestDetermineNextDuelPurelyEntropic:
             ]
         )
 
-        forking_dir = tmp_path / "forking_path"
+        forking_dir = tmp_path / "narrative_paths"
         forking_dir.mkdir()
         ratings_dir = tmp_path / "ratings"
         ratings_dir.mkdir()
@@ -365,7 +365,7 @@ class TestDetermineNextDuelPurelyEntropic:
             ]
         )
 
-        forking_dir = tmp_path / "forking_path"
+        forking_dir = tmp_path / "narrative_paths"
         forking_dir.mkdir()
         ratings_dir = tmp_path / "ratings"
         ratings_dir.mkdir()

--- a/tests/test_graph_logic.py
+++ b/tests/test_graph_logic.py
@@ -37,7 +37,7 @@ def _setup_data_manager_and_check_consistency(fork_dir_path: Path):
 
 
 def test_is_narrative_consistent(tmp_path: Path):
-    fork_dir = tmp_path / "forking_path"
+    fork_dir = tmp_path / "narrative_paths"
     fork_dir.mkdir()
 
     # Generate UUIDs for testing using storage.compute_narrative_path_uuid

--- a/tests/test_protocol_v2.py
+++ b/tests/test_protocol_v2.py
@@ -27,14 +27,14 @@ class TestProtocolV2(unittest.TestCase):
         cls.base_dir.mkdir(parents=True, exist_ok=True)
         # Define specific paths for test data
         cls.library_path = cls.base_dir / "the_library"
-        cls.forking_path_dir = cls.base_dir / "forking_path"
+        cls.narrative_paths_dir = cls.base_dir / "narrative_paths"
         cls.ratings_dir = cls.base_dir / "ratings"
         cls.transactions_dir = cls.base_dir / "data" / "transactions"
         cls.sessions_dir = cls.base_dir / "data" / "sessions"
         cls.canonical_path_file = cls.base_dir / "data" / "canonical_path.json"
 
         cls.library_path.mkdir(parents=True, exist_ok=True)
-        cls.forking_path_dir.mkdir(parents=True, exist_ok=True)
+        cls.narrative_paths_dir.mkdir(parents=True, exist_ok=True)
         cls.ratings_dir.mkdir(parents=True, exist_ok=True)
         cls.transactions_dir.parent.mkdir(parents=True, exist_ok=True)
         cls.transactions_dir.mkdir(parents=True, exist_ok=True)
@@ -46,14 +46,14 @@ class TestProtocolV2(unittest.TestCase):
         shutil.rmtree(cls.base_dir, ignore_errors=True)
 
     def setUp(self):
-        shutil.rmtree(self.forking_path_dir, ignore_errors=True)
+        shutil.rmtree(self.narrative_paths_dir, ignore_errors=True)
         shutil.rmtree(self.ratings_dir, ignore_errors=True)
         shutil.rmtree(self.transactions_dir, ignore_errors=True)
         shutil.rmtree(self.sessions_dir, ignore_errors=True)
         if self.canonical_path_file.exists():
             self.canonical_path_file.unlink()
 
-        self.forking_path_dir.mkdir(parents=True, exist_ok=True)
+        self.narrative_paths_dir.mkdir(parents=True, exist_ok=True)
         self.ratings_dir.mkdir(parents=True, exist_ok=True)
         self.transactions_dir.mkdir(parents=True, exist_ok=True)
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
@@ -62,14 +62,16 @@ class TestProtocolV2(unittest.TestCase):
         self.original_tm_transactions_dir = transaction_manager.TRANSACTIONS_DIR
         self.original_tm_head_file = transaction_manager.HEAD_FILE
         self.original_sm_sessions_dir = session_manager.SESSIONS_DIR
-        self.original_sm_consumed_file = session_manager.CONSUMED_PATHS_FILE # Changed FORKS to PATHS
+        self.original_sm_consumed_file = (
+            session_manager.CONSUMED_PATHS_FILE
+        )  # Changed FORKS to PATHS
         self.original_storage_uuid_namespace = storage.UUID_NAMESPACE
 
         self.original_dm_fork_csv_dir = storage.data_manager.fork_csv_dir
         self.original_dm_ratings_csv_dir = storage.data_manager.ratings_csv_dir
         self.original_dm_transactions_json_dir = storage.data_manager.transactions_json_dir
 
-        storage.data_manager.fork_csv_dir = self.forking_path_dir
+        storage.data_manager.fork_csv_dir = self.narrative_paths_dir
         storage.data_manager.ratings_csv_dir = self.ratings_dir
         storage.data_manager.transactions_json_dir = self.transactions_dir
 
@@ -89,7 +91,9 @@ class TestProtocolV2(unittest.TestCase):
         transaction_manager.TRANSACTIONS_DIR = self.original_tm_transactions_dir
         transaction_manager.HEAD_FILE = self.original_tm_head_file
         session_manager.SESSIONS_DIR = self.original_sm_sessions_dir
-        session_manager.CONSUMED_PATHS_FILE = self.original_sm_consumed_file # Changed FORKS to PATHS
+        session_manager.CONSUMED_PATHS_FILE = (
+            self.original_sm_consumed_file
+        )  # Changed FORKS to PATHS
         storage.UUID_NAMESPACE = self.original_storage_uuid_namespace
 
         storage.data_manager.fork_csv_dir = self.original_dm_fork_csv_dir
@@ -150,9 +154,9 @@ class TestProtocolV2(unittest.TestCase):
                 [
                     "session",
                     "start",
-                    "--path-uuid", # Changed --fork-uuid to --path-uuid
+                    "--path-uuid",  # Changed --fork-uuid to --path-uuid
                     path_uuid,
-                    # "--forking-path-dir", str(self.forking_path_dir), # Removed
+                    # "--forking-path-dir", str(self.narrative_paths_dir), # Removed
                     # "--ratings-dir", str(self.ratings_dir), # Removed
                     "--canonical-path-file",
                     str(self.canonical_path_file),
@@ -253,7 +257,7 @@ class TestProtocolV2(unittest.TestCase):
 
         tx_result_data = transaction_manager.record_transaction(
             session_id=dummy_session_id,
-            initiating_path_uuid=dummy_initiating_voter_path_uuid, # Ensure this is path_uuid
+            initiating_fork_uuid=dummy_initiating_voter_path_uuid,  # Ensure this is path_uuid
             session_verdicts=votes_to_qualify_fgood,
         )
         self.assertIsNotNone(tx_result_data)
@@ -341,7 +345,7 @@ class TestProtocolV2(unittest.TestCase):
 
         qualifying_tx_data = transaction_manager.record_transaction(
             session_id=str(uuid.uuid4()),
-            initiating_path_uuid=ds_initiating_path_uuid, # Ensure this is path_uuid
+            initiating_fork_uuid=ds_initiating_path_uuid,  # Ensure this is path_uuid
             session_verdicts=votes_for_qualification,
         )
         self.assertIsNotNone(qualifying_tx_data)
@@ -379,7 +383,7 @@ class TestProtocolV2(unittest.TestCase):
                 "--fork-uuid",
                 path_to_spend_uuid,
                 "--forking-path-dir",
-                str(self.forking_path_dir),
+                str(self.narrative_paths_dir),
                 "--ratings-dir",
                 str(self.ratings_dir),
                 "--canonical-path-file",
@@ -410,7 +414,7 @@ class TestProtocolV2(unittest.TestCase):
                 "--verdicts",
                 json.dumps(verdicts_for_commit),
                 "--forking-path-dir",
-                str(self.forking_path_dir),
+                str(self.narrative_paths_dir),
                 "--ratings-dir",
                 str(self.ratings_dir),
                 "--canonical-path-file",
@@ -438,10 +442,10 @@ class TestProtocolV2(unittest.TestCase):
             [
                 "session",
                 "start",
-                    "--path-uuid", # Changed --fork-uuid to --path-uuid
+                "--path-uuid",  # Changed --fork-uuid to --path-uuid
                 path_to_spend_uuid,
-                    # "--forking-path-dir", str(self.forking_path_dir), # Removed
-                    # "--ratings-dir", str(self.ratings_dir), # Removed
+                # "--forking-path-dir", str(self.narrative_paths_dir), # Removed
+                # "--ratings-dir", str(self.ratings_dir), # Removed
                 "--canonical-path-file",
                 str(self.canonical_path_file),
             ],
@@ -536,7 +540,7 @@ class TestProtocolV2(unittest.TestCase):
 
         transaction_manager.record_transaction(
             session_id=str(uuid.uuid4()),
-            initiating_path_uuid=tc_initiating_path_uuid, # Ensure this is path_uuid
+            initiating_fork_uuid=tc_initiating_path_uuid,  # Ensure this is path_uuid
             session_verdicts=votes_for_qf_qualification,
         )
 
@@ -556,11 +560,11 @@ class TestProtocolV2(unittest.TestCase):
             [
                 "session",
                 "start",
-                    "--path-uuid",
+                "--path-uuid",
                 qf_path_uuid,
-                    # No longer passing these as session_start uses DataManager internally
-                    # "--forking-path-dir", str(self.forking_path_dir),
-                    # "--ratings-dir", str(self.ratings_dir),
+                # No longer passing these as session_start uses DataManager internally
+                # "--forking-path-dir", str(self.narrative_paths_dir),
+                # "--ratings-dir", str(self.ratings_dir),
                 "--canonical-path-file",
                 str(self.canonical_path_file),
             ],
@@ -580,7 +584,7 @@ class TestProtocolV2(unittest.TestCase):
                 "--verdicts",
                 json.dumps(verdicts_to_change_canon),
                 "--forking-path-dir",
-                str(self.forking_path_dir),
+                str(self.narrative_paths_dir),
                 "--ratings-dir",
                 str(self.ratings_dir),
                 "--canonical-path-file",

--- a/tests/test_ranking_filtering.py
+++ b/tests/test_ranking_filtering.py
@@ -15,7 +15,7 @@ def _uuid(name: str) -> str:
 
 @pytest.fixture
 def temp_data_dir(tmp_path: Path) -> tuple[Path, Path]:
-    forking_dir = tmp_path / "forking_path"
+    forking_dir = tmp_path / "narrative_paths"
     ratings_dir = tmp_path / "ratings"
     forking_dir.mkdir(exist_ok=True)
     ratings_dir.mkdir(exist_ok=True)
@@ -235,7 +235,7 @@ def test_get_ranking_for_position_0_no_predecessor(temp_data_dir):
     assert h0_alt_data["losses"] == 2
 
 
-def test_get_ranking_empty_forking_path_dir(temp_data_dir):
+def test_get_ranking_empty_narrative_paths_dir(temp_data_dir):
     _, ratings_dir = temp_data_dir
     forking_dir_empty = temp_data_dir[0]
 
@@ -339,7 +339,7 @@ def test_get_ranking_canonical_predecessor_none_not_pos_0(temp_data_dir):
     assert ranking_df.empty
 
 
-def test_get_ranking_forking_path_missing_columns(temp_data_dir):
+def test_get_ranking_narrative_paths_missing_columns(temp_data_dir):
     forking_dir, ratings_dir = temp_data_dir
     (forking_dir / "missing_cols.csv").write_text("uuid,fork_uuid\nval1,val2")
     create_csv(ratings_pos1_data, ratings_dir / "position_001.csv")

--- a/tests/test_ratings_ranking.py
+++ b/tests/test_ratings_ranking.py
@@ -45,15 +45,15 @@ PREDECESSOR_POS1 = "pred-pos1"
 def test_get_ranking(tmp_path: Path):
     ratings_dir_test_var = tmp_path / "ratings"
     ratings_dir_test_var.mkdir()
-    forking_path_dir = tmp_path / "forking_path"
-    forking_path_dir.mkdir()
+    narrative_paths_dir = tmp_path / "narrative_paths"
+    narrative_paths_dir.mkdir()
 
     fork_data = [
         {"position": 1, "prev_uuid": PREDECESSOR_POS1, "uuid": UUID_A, "fork_uuid": "fork-a"},
         {"position": 1, "prev_uuid": PREDECESSOR_POS1, "uuid": UUID_B, "fork_uuid": "fork-b"},
         {"position": 1, "prev_uuid": PREDECESSOR_POS1, "uuid": UUID_C, "fork_uuid": "fork-c"},
     ]
-    pd.DataFrame(fork_data).to_csv(forking_path_dir / "test_forks.csv", index=False)
+    pd.DataFrame(fork_data).to_csv(narrative_paths_dir / "test_forks.csv", index=False)
 
     votes_for_pos1 = [
         {"uuid": "vote1", "voter": "v1", "winner": UUID_A, "loser": UUID_B},
@@ -65,7 +65,7 @@ def test_get_ranking(tmp_path: Path):
     df = _call_get_ranking_with_setup(
         position=1,
         predecessor_hronir_uuid=PREDECESSOR_POS1,
-        forking_dir=forking_path_dir,
+        forking_dir=narrative_paths_dir,
         ratings_dir=ratings_dir_test_var,
     )
 

--- a/tests/test_sessions_and_cascade.py
+++ b/tests/test_sessions_and_cascade.py
@@ -15,14 +15,14 @@ runner = CliRunner()
 
 TEST_ROOT = Path("temp_test_data")
 LIBRARY_DIR_abs = (Path.cwd() / TEST_ROOT / "the_library").resolve()
-FORKING_PATH_DIR_abs = (Path.cwd() / TEST_ROOT / "forking_path").resolve()
+FORKING_PATH_DIR_abs = (Path.cwd() / TEST_ROOT / "narrative_paths").resolve()
 RATINGS_DIR_abs = (Path.cwd() / TEST_ROOT / "ratings").resolve()
 DATA_DIR_abs = (Path.cwd() / TEST_ROOT / "data").resolve()
 SESSIONS_DIR_fixture_abs = (DATA_DIR_abs / "sessions").resolve()
 TRANSACTIONS_DIR_fixture_abs = (DATA_DIR_abs / "transactions").resolve()
 CANONICAL_PATH_FILE_fixture_abs = (DATA_DIR_abs / "canonical_path.json").resolve()
 
-FORKING_PATH_DIR_runtime = Path("forking_path")
+FORKING_PATH_DIR_runtime = Path("narrative_paths")
 RATINGS_DIR_runtime = Path("ratings")
 DATA_DIR_runtime = Path("data")
 SESSIONS_DIR_runtime = DATA_DIR_runtime / "sessions"
@@ -230,7 +230,7 @@ def test_environment(monkeypatch):
 
     resolved_test_root.mkdir(parents=True)
     (resolved_test_root / "the_library").mkdir(parents=True, exist_ok=True)
-    (resolved_test_root / "forking_path").mkdir(parents=True, exist_ok=True)
+    (resolved_test_root / "narrative_paths").mkdir(parents=True, exist_ok=True)
     (resolved_test_root / "ratings").mkdir(parents=True, exist_ok=True)
     (resolved_test_root / "data").mkdir(parents=True, exist_ok=True)
     (resolved_test_root / "data" / "sessions").mkdir(parents=True, exist_ok=True)
@@ -244,7 +244,7 @@ def test_environment(monkeypatch):
     original_tx_dir = storage.data_manager.transactions_json_dir
     original_initialized = storage.data_manager._initialized
 
-    storage.data_manager.fork_csv_dir = Path("forking_path")
+    storage.data_manager.fork_csv_dir = Path("narrative_paths")
     storage.data_manager.ratings_csv_dir = Path("ratings")
     storage.data_manager.transactions_json_dir = Path("data") / "transactions"
 

--- a/tests/test_system_dynamics.py
+++ b/tests/test_system_dynamics.py
@@ -45,7 +45,7 @@ def setup_test_environment(tmp_path: Path) -> dict[str, Path]:
     data_dir.mkdir(parents=True, exist_ok=True)
     library_dir = tmp_path / "the_library"
     library_dir.mkdir(parents=True, exist_ok=True)
-    fork_dir = tmp_path / "forking_path"
+    fork_dir = tmp_path / "narrative_paths"
     fork_dir.mkdir(parents=True, exist_ok=True)
     ratings_dir = tmp_path / "ratings"
     ratings_dir.mkdir(parents=True, exist_ok=True)
@@ -110,7 +110,7 @@ def setup_test_environment(tmp_path: Path) -> dict[str, Path]:
         position=1, prev_uuid=hronir_B_suc, cur_uuid=hronir_F_suc
     )
 
-    # Create forking_path CSV
+    # Create narrative_paths CSV
     forks_data = [
         {"position": 0, "prev_uuid": "", "uuid": hronir_A_suc, "fork_uuid": fork_A_uuid},
         {"position": 0, "prev_uuid": "", "uuid": hronir_B_suc, "fork_uuid": fork_B_uuid},
@@ -151,7 +151,7 @@ def setup_test_environment(tmp_path: Path) -> dict[str, Path]:
     voter_for_initial_ratings_fork_uuid = storage.compute_forking_uuid(
         position=99, prev_uuid="", cur_uuid=dummy_voter_hronir_uuid
     )
-    # Add this dummy fork to a separate CSV to ensure it's found by storage.forking_path_exists
+    # Add this dummy fork to a separate CSV to ensure it's found by storage.narrative_paths_exists
     create_fork_csv(
         fork_dir,
         "dummy_forks.csv",


### PR DESCRIPTION
## Summary
- adjust tests for narrative path storage changes
- update calls to `record_transaction()` with `initiating_fork_uuid`

## Testing
- `uv run ruff format tests`
- `uv run ruff check tests`
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest` *(fails: 14 failed, 14 passed, 1 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68613fe67d388325993e2747813ea087