### PR TITLE
Apply patch updating transaction HEAD and tests

### DIFF
--- a/hronir_encyclopedia/transaction_manager.py
+++ b/hronir_encyclopedia/transaction_manager.py
@@ -165,7 +165,7 @@ def record_transaction(
         f.write(transaction_model_data.model_dump_json(indent=2))
 
     # Update HEAD to point to this new transaction
-    # HEAD_FILE.write_text(str(transaction_uuid_obj)) # This was missing
+    HEAD_FILE.write_text(str(transaction_uuid_obj))
 
     dm.save_all_data_to_csvs()
 

--- a/tests/test_sessions_and_cascade.py
+++ b/tests/test_sessions_and_cascade.py
@@ -302,7 +302,7 @@ class TestSessionWorkflow:
         cmd_args_start = [
             "session",
             "start",
-            "--fork-uuid",
+            "--path-uuid",
             f2_judge_path_uuid,
         ]
 


### PR DESCRIPTION
## Summary
- ensure transaction_manager updates HEAD file
- add helper for reading transaction HEAD in tests
- adjust protocol_v2 tests to new argument names
- update cascade test to use `--path-uuid`

## Testing
- `uv run ruff format hronir_encyclopedia/transaction_manager.py tests/test_protocol_v2.py`
- `uv run ruff check hronir_encyclopedia/transaction_manager.py tests/test_protocol_v2.py`
- `uv run pytest` *(fails: test_graph_logic.py::test_is_narrative_consistent and others)*

------
https://chatgpt.com/codex/tasks/task_e_68614cd86ce8832584ba67eaacb9b7c0